### PR TITLE
feat(schedule-screen): swipe between schedules, animated day picker

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -191,7 +191,7 @@ const $pressedTextPresets: Record<Presets, StyleProp<TextStyle>> = {
 }
 
 const $baseShadowStyle: ViewStyle = {
-  paddingBottom: 4,
+  paddingBottom: spacing.tiny,
   borderRadius: 100,
   borderColor: colors.palette.neutral500,
 }

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -199,7 +199,7 @@ export function Card(props: CardProps) {
         setCardWidth(e.nativeEvent.layout.width)
       }}
     >
-      <View style={[$offsetContainer]}>
+      <View style={$offsetContainer}>
         <Image
           style={[$offsetStyle, { height: cardHeight, width: cardWidth - spacing.tiny }]}
           resizeMode="stretch"

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -190,16 +190,18 @@ export function Card(props: CardProps) {
   const $offsetStyle = [$offsetPresets[preset]]
 
   const [cardHeight, setCardHeight] = React.useState(null)
+  const [cardWidth, setCardWidth] = React.useState(null)
 
   return (
     <View
       onLayout={(e) => {
         setCardHeight(e.nativeEvent.layout.height)
+        setCardWidth(e.nativeEvent.layout.width)
       }}
     >
-      <View style={$offsetContainer}>
+      <View style={[$offsetContainer]}>
         <Image
-          style={[$offsetStyle, { height: cardHeight }]}
+          style={[$offsetStyle, { height: cardHeight, width: cardWidth - spacing.tiny }]}
           resizeMode="stretch"
           source={cardOffset}
         />
@@ -265,7 +267,6 @@ const $containerBase: ViewStyle = {
   borderWidth: 1,
   flexDirection: "row",
   zIndex: 2,
-  elevation: 2,
   marginRight: spacing.tiny,
 }
 
@@ -302,7 +303,6 @@ const $offsetContainer: ViewStyle = {
   position: "absolute",
   left: spacing.tiny,
   top: spacing.tiny,
-  elevation: 1,
   zIndex: 1,
 }
 

--- a/app/models/mock-data.json
+++ b/app/models/mock-data.json
@@ -1,4 +1,4 @@
-[ 
+[
   {
     "date": "2023-05-17",
     "title": "React Native Workshops",
@@ -12,14 +12,14 @@
       {
         "variant": "workshop",
         "time": "6:00 — 8:00 am",
-        "eventTitle": "Check-in & Registration",
-        "heading": "Gant Laborde",
-        "subheading": "Leveling up on the new architecture"
+        "eventTitle": "Advanced Workshop",
+        "subheading": "Gant Laborde",
+        "heading": "Leveling up on the new architecture"
       },
       {
         "variant": "talk",
         "time": "6:00 — 8:00 am",
-        "eventTitle": "Check-in & Registration",
+        "eventTitle": "talk",
         "heading": "Ferran Negre Pizarro",
         "subheading": "React Native case study: from an idea to market"
       }

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -56,7 +56,7 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
     const translateX = interpolate(
       scrollX.value,
       inputRange,
-      measures.map((measure) => measure.x - spacing.micro),
+      measures.map((measure) => measure.x + (index - spacing.micro)),
     )
 
     return {

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -1,22 +1,42 @@
 import { observer } from "mobx-react-lite"
 import React, { FC } from "react"
 import { Dimensions, Pressable, TextStyle, View, ViewStyle } from "react-native"
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated"
+import Animated, { useAnimatedStyle, SharedValue, interpolate } from "react-native-reanimated"
 import { Text } from "../../components"
 import { useStores } from "../../models"
 import { colors, spacing } from "../../theme"
 import { formatDate } from "../../utils/formatDate"
 
-export const ScheduleDayPicker: FC = observer(function ScheduleDayPicker() {
+type Props = {
+  scrollX: SharedValue<number>
+  onItemPress: (itemIndex) => void
+}
+
+const { width } = Dimensions.get("window")
+
+export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker({
+  scrollX,
+  onItemPress,
+}) {
   const { schedulesStore } = useStores()
   const { setSelectedSchedule, schedules, selectedSchedule } = schedulesStore
-  const leftValue = useSharedValue(0)
-  const wrapperWidth = Dimensions.get("screen").width - spacing.extraSmall * 2
+  const wrapperWidth = width - spacing.extraSmall * 2
   const widthSize = wrapperWidth / schedules.length
+
+  const inputRange = schedules.map((_, index) => index * width)
+  console.log({ inputRange, scrollX: scrollX.value })
+
+  const translateX = interpolate(
+    scrollX.value,
+    inputRange,
+    schedules.map((_, index) => widthSize * index),
+  )
 
   const $animatedLeftStyle = useAnimatedStyle(() => {
     return {
-      left: withTiming(leftValue.value, { duration: 300 }),
+      // left: clamp(scrollX.value - (spacing.small * index) / 2, 0, widthSize),
+      // left,
+      transform: [{ translateX }],
       width: widthSize,
     }
   })
@@ -28,8 +48,10 @@ export const ScheduleDayPicker: FC = observer(function ScheduleDayPicker() {
         <Pressable
           key={schedule.date}
           onPress={() => {
-            leftValue.value = widthSize * index
-            setTimeout(() => setSelectedSchedule(schedule), 250)
+            // onItemPress(index)
+            // leftValue.value = widthSize * index
+            // setTimeout(() => setSelectedSchedule(schedule), 250)
+            setSelectedSchedule(schedule)
           }}
           style={$buttonStyle}
         >

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -1,10 +1,15 @@
 import { observer } from "mobx-react-lite"
 import React, { FC } from "react"
 import { Dimensions, Pressable, TextStyle, View, ViewStyle } from "react-native"
-import Animated, { useAnimatedStyle, SharedValue, interpolate } from "react-native-reanimated"
+import Animated, {
+  useAnimatedStyle,
+  SharedValue,
+  interpolate,
+  interpolateColor,
+} from "react-native-reanimated"
 import { Text } from "../../components"
 import { useStores } from "../../models"
-import { colors, spacing } from "../../theme"
+import { colors, spacing, typography } from "../../theme"
 import { formatDate } from "../../utils/formatDate"
 
 type Props = {
@@ -22,6 +27,7 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
   const { setSelectedSchedule, schedules, selectedSchedule } = schedulesStore
   const wrapperWidth = width - spacing.extraSmall * 2
   const widthSize = wrapperWidth / schedules.length
+  const index = schedules.findIndex((s) => s.date === selectedSchedule.date)
 
   const containerRef = React.useRef()
   const [measures, setMeasures] = React.useState([{ x: 0 }, { x: 0 }, { x: 0 }])
@@ -59,6 +65,36 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
     }
   }, [inputRange, scrollX, measures])
 
+  const $animatedTextStyle0 = useAnimatedStyle(() => {
+    const color = interpolateColor(scrollX.value, inputRange, [
+      colors.palette.neutral900,
+      colors.palette.neutral100,
+      colors.palette.neutral100,
+    ])
+
+    return { color }
+  })
+
+  const $animatedTextStyle1 = useAnimatedStyle(() => {
+    const color = interpolateColor(scrollX.value, inputRange, [
+      colors.palette.neutral100,
+      colors.palette.neutral900,
+      colors.palette.neutral100,
+    ])
+
+    return { color }
+  })
+
+  const $animatedTextStyle2 = useAnimatedStyle(() => {
+    const color = interpolateColor(scrollX.value, inputRange, [
+      colors.palette.neutral100,
+      colors.palette.neutral100,
+      colors.palette.neutral900,
+    ])
+
+    return { color }
+  })
+
   return (
     <View ref={containerRef} style={$wrapperStyle}>
       {measures.length > 0 && <Animated.View style={[$animatedViewStyle, $animatedLeftStyle]} />}
@@ -72,12 +108,16 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
           }}
           style={$buttonStyle}
         >
-          <Text
-            preset="companionHeading"
-            style={[$textStyle, selectedSchedule.date === schedule.date && $textSelectedStyle]}
+          <Animated.Text
+            style={[
+              $textStyle,
+              index === 0 && $animatedTextStyle0,
+              index === 1 && $animatedTextStyle1,
+              index === 2 && $animatedTextStyle2,
+            ]}
           >
             {formatDate(schedule.date, "EE")}
-          </Text>
+          </Animated.Text>
         </Pressable>
       ))}
     </View>
@@ -100,12 +140,9 @@ const $buttonBaseStyle: ViewStyle = {
 
 const $textStyle: TextStyle = {
   color: colors.palette.neutral100,
+  fontFamily: typography.primary.medium,
   fontSize: 16,
   lineHeight: 22.4,
-}
-
-const $textSelectedStyle: TextStyle = {
-  color: colors.palette.neutral900,
 }
 
 const $wrapperStyle: ViewStyle[] = [

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -22,33 +22,31 @@ type AnimatedDayButtonProps = {
   inputRange: number[]
 }
 
-const AnimatedDayButton = observer(
-  React.forwardRef(
-    (
-      { onPress, index, text, scrollX, inputRange }: AnimatedDayButtonProps,
-      ref: MutableRefObject<View>,
-    ) => {
-      const { schedulesStore } = useStores()
-      const { schedules } = schedulesStore
+const AnimatedDayButtonRef = React.forwardRef(
+  (props: AnimatedDayButtonProps, ref: MutableRefObject<View>) => {
+    const { onPress, index, text, scrollX, inputRange } = props
+    const { schedulesStore } = useStores()
+    const { schedules } = schedulesStore
+    const outputRange = schedules.map((_, scheduleIndex) =>
+      index === scheduleIndex ? colors.palette.neutral900 : colors.palette.neutral100,
+    )
 
-      const outputRange = schedules.map((_, scheduleIndex) =>
-        index === scheduleIndex ? colors.palette.neutral900 : colors.palette.neutral100,
-      )
+    const $animatedTextStyle = useAnimatedStyle(() => {
+      const color = interpolateColor(scrollX.value, inputRange, outputRange)
 
-      const $animatedTextStyle = useAnimatedStyle(() => {
-        const color = interpolateColor(scrollX.value, inputRange, outputRange)
+      return { color }
+    })
 
-        return { color }
-      })
-
-      return (
-        <Pressable {...{ ref, onPress }} style={$buttonStyle}>
-          <Animated.Text style={[$textStyle, $animatedTextStyle]}>{text}</Animated.Text>
-        </Pressable>
-      )
-    },
-  ),
+    return (
+      <Pressable {...{ ref, onPress }} style={$buttonStyle}>
+        <Animated.Text style={[$textStyle, $animatedTextStyle]}>{text}</Animated.Text>
+      </Pressable>
+    )
+  },
 )
+
+AnimatedDayButtonRef.displayName = "AnimatedDayButton"
+const AnimatedDayButton = observer(AnimatedDayButtonRef)
 
 type ScheduleDayPickerProps = {
   scrollX: SharedValue<number>

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -26,11 +26,11 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
 
   const containerRef = React.useRef()
   const [measures, setMeasures] = React.useState([{ x: 0 }, { x: 0 }, { x: 0 }])
-  const itemRefs = schedules.map((item) => React.createRef<View>())
+  const itemRefs = schedules.map((_) => React.createRef<View>())
 
   React.useEffect(() => {
     const m = []
-    schedules.map((item, index) => {
+    schedules.map((_, index) => {
       itemRefs[index].current.measureLayout(
         containerRef.current,
         (x, y, width, height) => {
@@ -48,14 +48,14 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
   const inputRange = schedules.map((_, index) => index * width)
 
   const $animatedLeftStyle = useAnimatedStyle(() => {
-    const left = interpolate(
+    const translateX = interpolate(
       scrollX.value,
       inputRange,
       measures.map((measure) => measure.x - spacing.micro),
     )
 
     return {
-      left,
+      transform: [{ translateX }],
       width: widthSize,
     }
   }, [inputRange, scrollX, measures])
@@ -69,8 +69,6 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
           ref={itemRefs[index]}
           onPress={() => {
             // onItemPress(index)
-            // leftValue.value = widthSize * index
-            // setTimeout(() => setSelectedSchedule(schedule), 250)
             setSelectedSchedule(schedule)
           }}
           style={$buttonStyle}

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -1,4 +1,3 @@
-import { ReactNativeFirebase } from "@react-native-firebase/app"
 import { observer } from "mobx-react-lite"
 import React, { FC } from "react"
 import { Dimensions, Pressable, TextStyle, View, ViewStyle } from "react-native"
@@ -68,7 +67,7 @@ export const ScheduleDayPicker: FC<Props> = observer(function ScheduleDayPicker(
           key={schedule.date}
           ref={itemRefs[index]}
           onPress={() => {
-            // onItemPress(index)
+            onItemPress(index)
             setSelectedSchedule(schedule)
           }}
           style={$buttonStyle}

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -30,13 +30,29 @@ export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function 
     fetchData()
   }, [fetchData])
 
+  const updateSchedule = (index) => setSelectedSchedule(schedules[index])
+
   const scrollX = useSharedValue(0)
   // const ref = React.useRef(null)
   const ref = useAnimatedRef()
-  const scrollHandler = useAnimatedScrollHandler((event) => {
-    // /3
-    scrollX.value = event.contentOffset.x // why can't we use schedules.length here?
-  })
+  const scrollHandler = useAnimatedScrollHandler(
+    {
+      onScroll: (event) => {
+        // /3
+        scrollX.value = event.contentOffset.x // why can't we use schedules.length here?
+      },
+      onMomentumEnd: (event) => {
+        const contentOffset = event.contentOffset
+        const viewSize = event.layoutMeasurement
+
+        // Divide the horizontal offset by the width of the view to see which page is visible
+        const index = Math.floor(contentOffset.x / viewSize.width)
+        // updateSchedule(index)
+      },
+    },
+    // [updateSchedule],
+  )
+
   const onItemPress = React.useCallback(
     (itemIndex) => {
       scrollTo(ref, itemIndex * width, 0, true)
@@ -58,14 +74,6 @@ export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function 
           horizontal
           showsHorizontalScrollIndicator={false}
           pagingEnabled
-          onMomentumScrollEnd={(event) => {
-            const contentOffset = event.nativeEvent.contentOffset
-            const viewSize = event.nativeEvent.layoutMeasurement
-
-            // Divide the horizontal offset by the width of the view to see which page is visible
-            const index = Math.floor(contentOffset.x / viewSize.width)
-            setSelectedSchedule(schedules[index])
-          }}
           onScroll={scrollHandler}
           bounces={false}
           renderItem={({ item: schedule }) => (

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -17,7 +17,7 @@ import Animated, {
   runOnJS,
 } from "react-native-reanimated"
 
-const { width } = Dimensions.get("screen")
+const { width } = Dimensions.get("window")
 
 export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function ScheduleScreen() {
   useHeader({ title: "Schedule" })

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -1,8 +1,8 @@
-import React, { FC, Fragment, useLayoutEffect } from "react"
+import React, { FC, useLayoutEffect } from "react"
 import { observer } from "mobx-react-lite"
-import { View, TextStyle, ViewStyle } from "react-native"
+import { View, TextStyle, ViewStyle, Dimensions } from "react-native"
 import { ContentStyle, FlashList } from "@shopify/flash-list"
-import { Screen, Text } from "../../components"
+import { Text } from "../../components"
 import { TabScreenProps } from "../../navigators/TabNavigator"
 import { colors, spacing } from "../../theme"
 import { useHeader } from "../../hooks/useHeader"
@@ -11,63 +11,112 @@ import ScheduleCard, { ScheduleCardProps, Variants } from "./ScheduleCard"
 import { useStores } from "../../models"
 import { formatDate } from "../../utils/formatDate"
 import { useAppNavigation } from "../../hooks"
+import Animated, {
+  useAnimatedRef,
+  useAnimatedScrollHandler,
+  useSharedValue,
+  scrollTo,
+} from "react-native-reanimated"
+
+const { width } = Dimensions.get("screen")
 
 export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function ScheduleScreen() {
   useHeader({ title: "Schedule" })
   const navigation = useAppNavigation()
   const { schedulesStore } = useStores()
-  const { fetchData, selectedSchedule } = schedulesStore
+  const { fetchData, setSelectedSchedule, selectedSchedule, schedules } = schedulesStore
 
   useLayoutEffect(() => {
     fetchData()
   }, [fetchData])
 
+  const scrollX = useSharedValue(0)
+  // const ref = React.useRef(null)
+  const ref = useAnimatedRef()
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    // /3
+    scrollX.value = event.contentOffset.x // why can't we use schedules.length here?
+  })
+  const onItemPress = React.useCallback(
+    (itemIndex) => {
+      scrollTo(ref, itemIndex * width, 0, true)
+      // ref?.current?.scrollToOffset({ offset: itemIndex * width })
+    },
+    [ref],
+  )
+
   if (!selectedSchedule) return null
 
   return (
     <>
-      <Screen style={$root} preset="scroll" contentContainerStyle={$container}>
-        <Text preset="heading" style={$heading}>
-          {formatDate(selectedSchedule.date, "EE, MMMM dd")}
-        </Text>
-        <Text style={$subheading}>{selectedSchedule.title}</Text>
+      <View style={$root}>
+        <Animated.FlatList
+          // contentContainerStyle={{ height: 200 }}
+          // ref={ref}
+          data={schedules}
+          keyExtractor={(item) => item.date}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          pagingEnabled
+          onMomentumScrollEnd={(event) => {
+            const contentOffset = event.nativeEvent.contentOffset
+            const viewSize = event.nativeEvent.layoutMeasurement
 
-        <View style={$listContainer}>
-          <FlashList
-            data={selectedSchedule.events}
-            renderItem={({ item }: { item: ScheduleCardProps }) => {
-              const { time, eventTitle, heading, subheading } = item
-              const onPress =
-                item.variant !== "event" ? () => navigation.navigate("TalkDetails") : undefined
-              return (
-                <View style={$cardContainer}>
-                  <ScheduleCard
-                    variant={item.variant as Variants}
-                    {...{ time, eventTitle, heading, subheading, onPress }}
-                  />
-                </View>
-              )
-            }}
-            getItemType={(item) => {
-              // To achieve better performance, specify the type based on the item
-              return item.variant
-            }}
-            estimatedItemSize={225}
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={$list}
-          />
-        </View>
-      </Screen>
-      <ScheduleDayPicker />
+            // Divide the horizontal offset by the width of the view to see which page is visible
+            const index = Math.floor(contentOffset.x / viewSize.width)
+            setSelectedSchedule(schedules[index])
+          }}
+          onScroll={scrollHandler}
+          bounces={false}
+          renderItem={({ item: schedule }) => (
+            <View style={[$container, { width }]}>
+              <FlashList
+                ListHeaderComponent={
+                  <View style={$headingContainer}>
+                    <Text preset="heading" style={$heading}>
+                      {formatDate(schedule.date, "EE, MMMM dd")}
+                    </Text>
+                    <Text style={$subheading}>{schedule.title}</Text>
+                  </View>
+                }
+                data={schedule.events}
+                renderItem={({ item }: { item: ScheduleCardProps }) => {
+                  const { time, eventTitle, heading, subheading } = item
+                  const onPress =
+                    item.variant !== "event" ? () => navigation.navigate("TalkDetails") : undefined
+                  return (
+                    <View style={$cardContainer}>
+                      <ScheduleCard
+                        variant={item.variant as Variants}
+                        {...{ time, eventTitle, heading, subheading, onPress }}
+                      />
+                    </View>
+                  )
+                }}
+                getItemType={(item) => {
+                  // To achieve better performance, specify the type based on the item
+                  return item.variant
+                }}
+                estimatedItemSize={225}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={$list}
+              />
+            </View>
+          )}
+        />
+      </View>
+      <ScheduleDayPicker {...{ scrollX, onItemPress }} />
     </>
   )
 })
 
 const $root: ViewStyle = {
   flex: 1,
+  backgroundColor: colors.background,
 }
 
 const $container: ViewStyle = {
+  flex: 1,
   paddingHorizontal: spacing.large,
 }
 
@@ -81,7 +130,7 @@ const $subheading: TextStyle = {
 }
 
 const $list: ContentStyle = {
-  paddingVertical: spacing.large,
+  paddingTop: spacing.medium,
   paddingBottom: 48 + spacing.medium,
 }
 
@@ -91,4 +140,8 @@ const $cardContainer: ViewStyle = {
 
 const $listContainer: ViewStyle = {
   height: "100%",
+}
+
+const $headingContainer: ViewStyle = {
+  paddingBottom: spacing.large,
 }

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -141,10 +141,6 @@ const $cardContainer: ViewStyle = {
   paddingBottom: spacing.large,
 }
 
-const $listContainer: ViewStyle = {
-  height: "100%",
-}
-
 const $headingContainer: ViewStyle = {
   paddingBottom: spacing.large,
 }

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -16,6 +16,7 @@ import Animated, {
   useAnimatedScrollHandler,
   useSharedValue,
   scrollTo,
+  runOnJS,
 } from "react-native-reanimated"
 
 const { width } = Dimensions.get("screen")
@@ -33,7 +34,6 @@ export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function 
   const updateSchedule = (index) => setSelectedSchedule(schedules[index])
 
   const scrollX = useSharedValue(0)
-  // const ref = React.useRef(null)
   const ref = useAnimatedRef()
   const scrollHandler = useAnimatedScrollHandler(
     {
@@ -47,12 +47,16 @@ export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function 
 
         // Divide the horizontal offset by the width of the view to see which page is visible
         const index = Math.floor(contentOffset.x / viewSize.width)
-        // updateSchedule(index)
+
+        // ? Why does this work this way with MST?
+        // Just passing runOnJS(setSelectedSchedule)(schedules[index]) here results in an MST error
+        runOnJS(updateSchedule)(index)
       },
     },
     // [updateSchedule],
   )
 
+  // TODO figure out reanimated scrollTo
   const onItemPress = React.useCallback(
     (itemIndex) => {
       scrollTo(ref, itemIndex * width, 0, true)
@@ -67,8 +71,6 @@ export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function 
     <>
       <View style={$root}>
         <Animated.FlatList
-          // contentContainerStyle={{ height: 200 }}
-          // ref={ref}
           data={schedules}
           keyExtractor={(item) => item.date}
           horizontal

--- a/app/screens/WelcomeScreen.tsx
+++ b/app/screens/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { Dimensions, Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
+import { Dimensions, Image, ImageStyle, Platform, TextStyle, View, ViewStyle } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { Button, Screen, Text } from "../components"
 import { useAppNavigation } from "../hooks"
@@ -8,6 +8,7 @@ import { AppStackScreenProps } from "../navigators"
 import { colors, spacing } from "../theme"
 
 const welcomeLogo = require("../../assets/images/welcome-shapes.png")
+const { width: screenWidth } = Dimensions.get("screen")
 
 interface WelcomeScreenProps extends AppStackScreenProps<"Welcome"> {}
 
@@ -76,12 +77,21 @@ const $bottomContainer: ViewStyle = {
   borderTopRightRadius: 16,
 }
 
-const $bottomContentContainer: ViewStyle = {
-  flex: 1,
-  paddingHorizontal: Dimensions.get("screen").width * 0.25,
-  paddingBottom: spacing.large,
-  justifyContent: "flex-end",
-}
+const $bottomContentContainer: ViewStyle = Platform.select({
+  ios: {
+    flex: 1,
+    paddingHorizontal: screenWidth * 0.25,
+    paddingBottom: spacing.large,
+    justifyContent: "flex-end",
+  },
+  android: {
+    flex: 1,
+    width: screenWidth * 0.5,
+    paddingBottom: spacing.large,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+})
 
 const $welcomeLogo: ImageStyle = {
   width: "100%",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.6",
     "react-native-gesture-handler": "~2.5.0",
-    "react-native-reanimated": "~2.9.1",
+    "react-native-reanimated": "~2.13.0",
     "react-native-safe-area-context": "4.3.1",
     "react-native-screens": "3.15.0",
     "react-native-web": "~0.18.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,7 +378,7 @@
     "@babel/helper-plugin-utils" "^7.18.9"
     "@babel/plugin-syntax-export-default-from" "^7.18.6"
 
-"@babel/plugin-proposal-export-namespace-from@^7.17.12", "@babel/plugin-proposal-export-namespace-from@^7.18.9":
+"@babel/plugin-proposal-export-namespace-from@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz#5f7313ab348cdb19d590145f9247540e94761203"
   integrity sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==
@@ -11495,12 +11495,11 @@ react-native-gradle-plugin@^0.0.7:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
-react-native-reanimated@~2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.9.1.tgz#d9a932e312c13c05b4f919e43ebbf76d996e0bc1"
-  integrity sha512-309SIhDBwY4F1n6e5Mr5D1uPZm2ESIcmZsGXHUu8hpKX4oIOlZj2MilTk+kHhi05LjChoJkcpfkstotCJmPRPg==
+react-native-reanimated@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.13.0.tgz#d64c1386626822d4dc22094b4efe028ff2c49cc9"
+  integrity sha512-yUHyYVIegWWIza4+nVyS3CSmI/Mc8kLFVHw2c6gnSHaYhYA4LeEjH/jBkoMzHk9Xd0Ra3cwtjYKAMG8OTp6JVg==
   dependencies:
-    "@babel/plugin-proposal-export-namespace-from" "^7.17.12"
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
     "@types/invariant" "^2.2.35"


### PR DESCRIPTION
# Description

[Screen: Schedule Screen](33-screen-schedule-screen)

- Does not close out the ticket, just adds the swiping functionality between lists
- Adds a horizontal FlatList for paging through daily schedules
- Animates day picker according to the horizontal scroll position
- Cleans up some Android specific styles

# Graphics

| iOS | Android |
| ------ | ------- |
| ![Simulator Screen Recording - iPhone 13 - 2022-11-21 at 14 53 50](https://user-images.githubusercontent.com/374022/203146537-d51be03d-bbc6-440a-9b6d-34d7be377d0e.gif) | <img src="https://user-images.githubusercontent.com/374022/203148280-26481cc4-8e0a-432b-b7fa-1adb7ec5e6e7.gif" width="280" /> |
# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features 
- [x] I have run tests and linter
