### PR TITLE
feat(schedule-screen): return to active day during conference

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -202,7 +202,6 @@ export function Card(props: CardProps) {
       <View style={$offsetContainer}>
         <Image
           style={[$offsetStyle, { height: cardHeight, width: cardWidth - spacing.tiny }]}
-          resizeMode="stretch"
           source={cardOffset}
         />
       </View>
@@ -294,6 +293,8 @@ const $offsetPresets = {
 
   reversed: [
     {
+      borderColor: colors.palette.primary500,
+      borderWidth: 1,
       tintColor: colors.palette.primary500,
     },
   ] as StyleProp<ImageStyle>,

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useAppNavigation"
 export * from "./useTabNavigation"
+export * from "./useAppState"

--- a/app/hooks/useAppState.ts
+++ b/app/hooks/useAppState.ts
@@ -9,7 +9,7 @@ type UseAppStateProps = {
 
 export function useAppState({ match, nextAppState, callback }: UseAppStateProps) {
   const appState = React.useRef(AppState.currentState)
-  const [appStateVisible, setAppStateVisible] = React.useState(appState.current)
+  const [_, setAppStateVisible] = React.useState(appState.current)
 
   React.useEffect(() => {
     // First time check (opening App from a killed state)
@@ -25,8 +25,9 @@ export function useAppState({ match, nextAppState, callback }: UseAppStateProps)
   }, [])
 
   const _handleAppStateChange = (newAppState) => {
+    // If the state we're coming from matches and
+    // the next state is the desired one, fire callback
     if (appState.current.match(match) && newAppState === nextAppState) {
-      console.tron.log(`App has changed state to ${nextAppState} from ${appStateVisible}`)
       callback()
     }
 

--- a/app/hooks/useAppState.ts
+++ b/app/hooks/useAppState.ts
@@ -1,0 +1,36 @@
+import React from "react"
+import { AppState, AppStateStatus } from "react-native"
+
+type UseAppStateProps = {
+  match: RegExp
+  nextAppState: AppStateStatus
+  callback: () => void
+}
+
+export function useAppState({ match, nextAppState, callback }: UseAppStateProps) {
+  const appState = React.useRef(AppState.currentState)
+  const [appStateVisible, setAppStateVisible] = React.useState(appState.current)
+
+  React.useEffect(() => {
+    // First time check (opening App from a killed state)
+    if (appState.current === nextAppState) {
+      callback()
+    }
+
+    // Set up event listener
+    const subscription = AppState.addEventListener("change", _handleAppStateChange)
+    return () => {
+      subscription.remove()
+    }
+  }, [])
+
+  const _handleAppStateChange = (newAppState) => {
+    if (appState.current.match(match) && newAppState === nextAppState) {
+      console.tron.log(`App has changed state to ${nextAppState} from ${appStateVisible}`)
+      callback()
+    }
+
+    appState.current = newAppState
+    setAppStateVisible(appState.current)
+  }
+}

--- a/app/models/SchedulesStore.ts
+++ b/app/models/SchedulesStore.ts
@@ -17,7 +17,9 @@ export const SchedulesStoreModel = types
   .actions((self) => ({
     fetchData() {
       self.schedules.replace(data as any)
-      self.setSelectedSchedule(self.schedules[0])
+      if (!self.selectedSchedule) {
+        self.setSelectedSchedule(self.schedules[0])
+      }
     },
   }))
 

--- a/app/models/SchedulesStore.ts
+++ b/app/models/SchedulesStore.ts
@@ -22,6 +22,11 @@ export const SchedulesStoreModel = types
       }
     },
   }))
+  .views((self) => ({
+    getScheduleIndex() {
+      return self.schedules.findIndex((schedule) => schedule.date === self.selectedSchedule.date)
+    },
+  }))
 
 export interface SchedulesStore extends Instance<typeof SchedulesStoreModel> {}
 export interface SchedulesStoreSnapshot extends SnapshotOut<typeof SchedulesStoreModel> {}

--- a/app/models/mock-data.json
+++ b/app/models/mock-data.json
@@ -28,11 +28,53 @@
   {
     "date": "2023-05-18",
     "title": "Conference Day 1",
-    "events": []
+    "events": [
+      {
+        "variant": "event",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "Check-in & Registration",
+        "subheading": "Check-in for attendees with a workshop ticket begins at 6:00 am."
+      },
+      {
+        "variant": "workshop",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "Advanced Workshop",
+        "subheading": "Gant Laborde",
+        "heading": "Leveling up on the new architecture"
+      },
+      {
+        "variant": "talk",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "talk",
+        "heading": "Ferran Negre Pizarro",
+        "subheading": "React Native case study: from an idea to market"
+      }
+    ]
   },
   {
     "date": "2023-05-19",
     "title": "Conference Day 2",
-    "events": []
+    "events": [
+      {
+        "variant": "event",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "Check-in & Registration",
+        "subheading": "Check-in for attendees with a workshop ticket begins at 6:00 am."
+      },
+      {
+        "variant": "workshop",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "Advanced Workshop",
+        "subheading": "Gant Laborde",
+        "heading": "Leveling up on the new architecture"
+      },
+      {
+        "variant": "talk",
+        "time": "6:00 — 8:00 am",
+        "eventTitle": "talk",
+        "heading": "Ferran Negre Pizarro",
+        "subheading": "React Native case study: from an idea to market"
+      }
+    ]
   }
 ]

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -58,7 +58,7 @@ export const ScheduleDayPicker: FC<ScheduleDayPickerProps> = observer(function S
   onItemPress,
 }) {
   const { schedulesStore } = useStores()
-  const { setSelectedSchedule, schedules, selectedSchedule } = schedulesStore
+  const { schedules, selectedSchedule } = schedulesStore
   const wrapperWidth = width - spacing.extraSmall * 2
   const widthSize = wrapperWidth / schedules.length
   const index = schedules.findIndex((s) => s.date === selectedSchedule.date)
@@ -111,7 +111,6 @@ export const ScheduleDayPicker: FC<ScheduleDayPickerProps> = observer(function S
           ref={itemRefs[index]}
           onPress={() => {
             onItemPress(index)
-            setSelectedSchedule(schedule)
           }}
           text={formatDate(schedule.date, "EE")}
           {...{ index, scrollX, inputRange }}

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -1,7 +1,13 @@
-import React, { FC, useLayoutEffect } from "react"
+import React from "react"
 import { observer } from "mobx-react-lite"
 import { View, TextStyle, ViewStyle, Dimensions } from "react-native"
 import { ContentStyle, FlashList } from "@shopify/flash-list"
+import Animated, {
+  useAnimatedScrollHandler,
+  useSharedValue,
+  runOnJS,
+} from "react-native-reanimated"
+import { useIsFocused } from "@react-navigation/native"
 import { Text } from "../../components"
 import { TabScreenProps } from "../../navigators/TabNavigator"
 import { colors, spacing } from "../../theme"
@@ -10,108 +16,173 @@ import { ScheduleDayPicker } from "./ScheduleDayPicker"
 import ScheduleCard, { ScheduleCardProps, Variants } from "./ScheduleCard"
 import { useStores } from "../../models"
 import { formatDate } from "../../utils/formatDate"
-import { useAppNavigation } from "../../hooks"
-import Animated, {
-  useAnimatedScrollHandler,
-  useSharedValue,
-  runOnJS,
-} from "react-native-reanimated"
+import { useAppNavigation, useAppState } from "../../hooks"
 
 const { width } = Dimensions.get("window")
 
-export const ScheduleScreen: FC<TabScreenProps<"Schedule">> = observer(function ScheduleScreen() {
-  useHeader({ title: "Schedule" })
-  const navigation = useAppNavigation()
-  const { schedulesStore } = useStores()
-  const { fetchData, setSelectedSchedule, selectedSchedule, schedules } = schedulesStore
+export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = observer(
+  function ScheduleScreen() {
+    useHeader({ title: "Schedule" })
 
-  useLayoutEffect(() => {
-    fetchData()
-  }, [fetchData])
+    const navigation = useAppNavigation()
+    const { schedulesStore } = useStores()
+    const { fetchData, setSelectedSchedule, selectedSchedule, schedules } = schedulesStore
+    const hScrollRef = React.useRef(null)
+    const scheduleListRefs = React.useMemo(() => {
+      return Object.fromEntries(
+        schedules.map((s) => [s.date, React.createRef<FlashList<ScheduleCardProps>>()]),
+      )
+    }, [])
+    const scrollX = useSharedValue(0)
+    const currentScheduleIndex = schedules.findIndex(
+      (schedule) => schedule.date === selectedSchedule.date,
+    )
+    const isFocused = useIsFocused()
 
-  const updateSchedule = (index) => setSelectedSchedule(schedules[index])
+    React.useLayoutEffect(() => {
+      fetchData()
+    }, [fetchData])
 
-  const scrollX = useSharedValue(0)
-  const ref = React.useRef(null)
-  const scrollHandler = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      scrollX.value = event.contentOffset.x
-    },
-    onMomentumEnd: (event) => {
-      const contentOffset = event.contentOffset
-      const viewSize = event.layoutMeasurement
+    const updateSchedule = React.useCallback(
+      (index) => {
+        console.tron.log("running update schedule", index, currentScheduleIndex)
+        if (index !== currentScheduleIndex) {
+          setSelectedSchedule(schedules[index])
+        }
+      },
+      [schedules, currentScheduleIndex],
+    )
 
-      // Divide the horizontal offset by the width of the view to see which page is visible
-      const index = Math.floor(contentOffset.x / viewSize.width)
+    const onItemPress = React.useCallback(
+      (itemIndex) => {
+        // TODO already on this index? scrollToTop
+        // console.tron.log({ currentScheduleIndex, itemIndex })
+        // if (currentScheduleIndex === itemIndex) {
+        //   scheduleListRefs[schedules[currentScheduleIndex].date]?.current?.scrollToOffset({
+        //     animated: true,
+        //     offset: 0,
+        //   })
+        //   updateSchedule(itemIndex)
+        // } else {
+        hScrollRef?.current?.scrollToOffset({ offset: itemIndex * width })
+        // }
+      },
+      // [hScrollRef, currentScheduleIndex],
+      [hScrollRef],
+    )
 
-      // ? Why does this work this way with MST?
-      // Just passing runOnJS(setSelectedSchedule)(schedules[index]) here results in an MST error
-      runOnJS(updateSchedule)(index)
-    },
-  })
+    const navigateToCurrentDay = React.useCallback(() => {
+      // Check if current date is in list of conference days
+      // If it is, navigate to that schedule's day
+      // If not, just skip and pick up where the user left off
+      const currentDate = "2023-05-19"
+      const conferenceDates = schedules.map((x) => x.date)
+      console.tron.log({ currentDate, conferenceDates })
+      const scheduleIndex = conferenceDates.findIndex((date) => date === currentDate)
+      if (scheduleIndex > -1) {
+        setTimeout(() => {
+          onItemPress(scheduleIndex)
+        }, 100)
+      }
 
-  const onItemPress = React.useCallback(
-    (itemIndex) => {
-      ref?.current?.scrollToOffset({ offset: itemIndex * width })
-    },
-    [ref],
-  )
+      // TODO: Scroll to the proper time of day talk in the FlashList
+      // setTimeout(() => {
+      //   scheduleListRefs[schedules[0].date]?.current?.scrollToIndex({ animated: true, index: 2 })
+      // }, 100)
+    }, [navigation, onItemPress, scheduleListRefs])
 
-  if (!selectedSchedule) return null
+    // When app comes from the background to the foreground, focus on the current day in the schedule
+    useAppState({
+      match: /background/,
+      nextAppState: "active",
+      callback: () => {
+        setTimeout(() => {
+          navigateToCurrentDay()
+        }, 250)
+      },
+    })
 
-  return (
-    <>
-      <View style={$root}>
-        <Animated.FlatList
-          ref={ref}
-          data={schedules}
-          keyExtractor={(item) => item.date}
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          pagingEnabled
-          onScroll={scrollHandler}
-          bounces={false}
-          renderItem={({ item: schedule }) => (
-            <View style={[$container, { width }]}>
-              <FlashList
-                ListHeaderComponent={
-                  <View style={$headingContainer}>
-                    <Text preset="heading" style={$heading}>
-                      {formatDate(schedule.date, "EE, MMMM dd")}
-                    </Text>
-                    <Text style={$subheading}>{schedule.title}</Text>
-                  </View>
-                }
-                data={schedule.events}
-                renderItem={({ item }: { item: ScheduleCardProps }) => {
-                  const { time, eventTitle, heading, subheading } = item
-                  const onPress =
-                    item.variant !== "event" ? () => navigation.navigate("TalkDetails") : undefined
-                  return (
-                    <View style={$cardContainer}>
-                      <ScheduleCard
-                        variant={item.variant as Variants}
-                        {...{ time, eventTitle, heading, subheading, onPress }}
-                      />
+    const scrollHandler = useAnimatedScrollHandler(
+      {
+        onScroll: (event) => {
+          scrollX.value = event.contentOffset.x
+        },
+        onMomentumEnd: (event) => {
+          const contentOffset = event.contentOffset
+          const viewSize = event.layoutMeasurement
+
+          // Divide the horizontal offset by the width of the view to see which page is visible
+          const index = Math.floor(contentOffset.x / viewSize.width)
+
+          // ! isFocused check for iOS, see details here: https://github.com/software-mansion/react-native-screens/issues/1183
+          if (isFocused) {
+            runOnJS(updateSchedule)(index)
+          }
+        },
+      },
+      [isFocused],
+    )
+
+    if (!selectedSchedule) return null
+
+    return (
+      <>
+        <View style={$root}>
+          <Animated.FlatList
+            ref={hScrollRef}
+            data={schedules}
+            keyExtractor={(item) => item.date}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            pagingEnabled
+            onScroll={scrollHandler}
+            bounces={false}
+            scrollEventThrottle={16}
+            renderItem={({ item: schedule }) => (
+              <View style={[$container, { width }]}>
+                <FlashList
+                  ref={scheduleListRefs[schedule.date]}
+                  ListHeaderComponent={
+                    <View style={$headingContainer}>
+                      <Text preset="heading" style={$heading}>
+                        {formatDate(schedule.date, "EE, MMMM dd")}
+                      </Text>
+                      <Text style={$subheading}>{schedule.title}</Text>
                     </View>
-                  )
-                }}
-                getItemType={(item) => {
-                  // To achieve better performance, specify the type based on the item
-                  return item.variant
-                }}
-                estimatedItemSize={225}
-                showsVerticalScrollIndicator={false}
-                contentContainerStyle={$list}
-              />
-            </View>
-          )}
-        />
-      </View>
-      <ScheduleDayPicker {...{ scrollX, onItemPress }} />
-    </>
-  )
-})
+                  }
+                  data={schedule.events}
+                  renderItem={({ item }: { item: ScheduleCardProps }) => {
+                    const { time, eventTitle, heading, subheading } = item
+                    const onPress =
+                      item.variant !== "event"
+                        ? () => navigation.navigate("TalkDetails")
+                        : undefined
+                    return (
+                      <View style={$cardContainer}>
+                        <ScheduleCard
+                          variant={item.variant as Variants}
+                          {...{ time, eventTitle, heading, subheading, onPress }}
+                        />
+                      </View>
+                    )
+                  }}
+                  getItemType={(item) => {
+                    // To achieve better performance, specify the type based on the item
+                    return item.variant
+                  }}
+                  estimatedItemSize={225}
+                  showsVerticalScrollIndicator={false}
+                  contentContainerStyle={$list}
+                />
+              </View>
+            )}
+          />
+        </View>
+        <ScheduleDayPicker {...{ scrollX, onItemPress }} />
+      </>
+    )
+  },
+)
 
 const $root: ViewStyle = {
   flex: 1,


### PR DESCRIPTION
# Description

[Screen: Schedule Screen](33-screen-schedule-screen)

- Upon pressing the day picker button, if the day is already selected, will scroll to top of the schedule list
- If the app is backgrounded or killed, the next time it is active we will scroll to the specific schedule for the current day when the conference is ongoing (both pre and post conference the user will just remain where they are) - the gif for this really doesn't show the traveling to the Desktop


# Graphics

| Top of list press | Backgrounded find correct day (pretend it's Thursday 😉) |
| ------ | ------- |
| <img src="https://user-images.githubusercontent.com/374022/203659088-df28cf90-1000-4069-bef4-f56cf5494714.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/374022/203660394-e83935eb-334e-4ca8-8103-b4cd29f3053c.gif" width="300" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features 
- [x] I have run tests and linter
