### PR TITLE
fix(ci): create build on main branch push only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,9 @@
 name: ci
 
-on:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
+on: [workflow_dispatch, push]
 
 jobs:
-  build-and-test:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
@@ -27,7 +23,11 @@ jobs:
 
       - name: Run linter
         run: yarn lint
-
+  build:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: [lint-and-test]
+    runs-on: ubuntu-latest
+    steps:
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v7
         with:


### PR DESCRIPTION
# Description

Setting tests/linter to run on push to any branch, but an EAS build to run on a push to `main` so the CI doesn't get so backlogged on PR updates.

Docs for reference:
- https://docs.github.com/en/actions/learn-github-actions/contexts#determining-when-to-use-contexts
- https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on