### PR TITLE
fix(talk-details): large shapes screen width

### DIFF
--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react"
-import { ViewStyle, View, TextStyle, ImageStyle, Image } from "react-native"
+import { ViewStyle, View, TextStyle, ImageStyle, Image, Dimensions } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { AppStackParamList } from "../../navigators"
 import { Text, Tag, IconButton, MIN_HEADER_HEIGHT, BoxShadow, Screen } from "../../components"
@@ -17,6 +17,8 @@ const talkCurve = require("../../../assets/images/talk-curve.png")
 const title = "React Native essentials"
 const subtitle = "Hotel, Conference Room 1"
 
+const SCREEN_WIDTH = Dimensions.get("screen").width
+
 export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDetails">> = () => {
   const scrollY = useSharedValue(0)
   const onPress = (url) => openLinkInBrowser(url)
@@ -31,7 +33,7 @@ export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDeta
   const { bottom: paddingBottom } = useSafeAreaInsets()
 
   // TODO: wire this up to the event type
-  const isWorkshop = true
+  const isWorkshop = false
 
   return (
     <Screen safeAreaEdges={["top", "bottom"]} style={$root}>
@@ -182,6 +184,8 @@ const $workshopCurve: ImageStyle = {
   position: "absolute",
   left: -spacing.large,
   top: spacing.huge - spacing.tiny,
+  width: SCREEN_WIDTH,
+  resizeMode: "stretch",
 }
 
 const $talkBlob: ImageStyle = {
@@ -193,6 +197,8 @@ const $talkBlob: ImageStyle = {
 const $talkCurve: ImageStyle = {
   position: "absolute",
   left: -spacing.large,
+  width: SCREEN_WIDTH,
+  resizeMode: "stretch",
 }
 
 const $title: TextStyle = {

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -33,7 +33,7 @@ export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDeta
   const { bottom: paddingBottom } = useSafeAreaInsets()
 
   // TODO: wire this up to the event type
-  const isWorkshop = false
+  const isWorkshop = true
 
   return (
     <Screen safeAreaEdges={["top", "bottom"]} style={$root}>


### PR DESCRIPTION
# Description

[Trello Card](63-bug-shapes-on-talk-details-screen-fall-short-of-edge-on-larger-screens)

Fixes the large curved shapes on the Talk Details screen to make it to the edge of larger screens


# Graphics

| Before | After |
| ------ | ------- |
| ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-12-13 at 14 24 51](https://user-images.githubusercontent.com/374022/207426858-c29069d1-701e-4857-926b-495b03211ea1.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-12-13 at 14 24 34](https://user-images.githubusercontent.com/374022/207426906-ae571f26-6129-4b8d-a87a-fd3d65c1277e.png) |
| ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-12-13 at 14 25 01](https://user-images.githubusercontent.com/374022/207426949-79354f43-e3ec-4f54-99a6-30275101a976.png) | ![Simulator Screen Shot - iPhone 14 Pro Max - 2022-12-13 at 14 24 41](https://user-images.githubusercontent.com/374022/207426965-5179fd3a-4304-498d-9814-b18d21ba0baa.png) |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features 
- [x] I have run tests and linter
