### PR TITLE
feat: scroll to the proper time of day talk card

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -46,6 +46,7 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
   }, [])
 
   const currentDate = format(new Date(), "yyyy-MM-dd")
+  const currentHour = new Date().getHours().toString()
 
   const scrollX = useSharedValue(0)
   const isFocused = useIsFocused()
@@ -85,11 +86,18 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
       }, 100)
     }
 
-    // TODO: Scroll to the proper time of day talk in the FlashList
-    // setTimeout(() => {
-    //   scheduleListRefs[schedules[0].date]?.current?.scrollToIndex({ animated: true, index: 2 })
-    // }, 100)
-  }, [onItemPress, scheduleListRefs, schedules, currentDate])
+    // Scroll to the proper time of day talk
+    setTimeout(() => {
+      const schedule = schedules[scheduleIndex]
+      const eventIndex = schedule?.events?.findIndex((e) => e.time.startsWith(currentHour))
+      if (eventIndex > -1) {
+        scheduleListRefs[schedule?.date]?.current?.scrollToIndex({
+          animated: true,
+          index: eventIndex,
+        })
+      }
+    }, 200)
+  }, [onItemPress, scheduleListRefs, schedules, currentDate, currentHour])
 
   // When app comes from the background to the foreground, focus on the current day in the schedule
   useAppState({

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -89,14 +89,15 @@ export const createScheduleScreenData = (): Schedule[] => {
 export const convertWorkshopToScheduleCard = (
   workshopData?: WorkshopProps[],
 ): ScheduleCardProps[] => {
-  return workshopData?.map((workshop) => {
+  return workshopData?.map((workshop, index) => {
     const sources = [workshop["instructor-info"]["speaker-photo"].url]
     if (workshop["second-instructor-2"]) {
       sources.push(workshop["second-instructor-2"]["speaker-photo"].url)
     }
     return {
       variant: "workshop",
-      time: "00:00",
+      // Temporary solution for workshop time for testing centering the card on the screen
+      time: `${index}:00`,
       eventTitle: "workshop",
       heading: workshop.name,
       subheading: workshop["instructor-info"].name,
@@ -112,9 +113,10 @@ const convertScheduleToScheduleCard = (
   key: string,
 ): ScheduleCardProps[] => {
   const groupScheduleData: ScheduleProps[] = groupBy("day-time")(scheduleData ?? [])?.[key] ?? []
-  return groupScheduleData.map((schedule) => ({
+  return groupScheduleData.map((schedule, index) => ({
     variant: schedule.type === "Talk" || schedule.type === "Lightning Talk" ? "talk" : "event",
-    time: "00:00",
+    // Temporary solution for workshop time for testing centering the card on the screen
+    time: `${index}:00`,
     eventTitle:
       schedule.type === "Talk"
         ? "talk"


### PR DESCRIPTION
# Description

Trello: 49-enhancement-center-schedule-list-around-the-current-ongoing-talk

Summary of the changes and any helpful notes for reviewers and testers. 

- Adds logic to center the ongoing talk card 

# Graphics

| iOS | Android |
| ------ | ------- |
|<video width="350" src="https://user-images.githubusercontent.com/53795920/207957039-57528b0f-4ec1-4065-86e7-8790ca0ef15f.mp4" />|<video width="350" src="https://user-images.githubusercontent.com/53795920/207957131-e9df6a49-ff5c-42d6-a0f3-500db2856b61.mp4" />|



# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features 
- [ ] I have run tests and linter
