### PR TITLE
feat: hide dark status bar during splash

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,86 +1,72 @@
-import { ExpoConfig, ConfigContext } from "@expo/config"
-import { ConfigPlugin, withInfoPlist } from "expo/config-plugins"
-import { version } from "./package.json"
+import { ExpoConfig, ConfigContext } from '@expo/config';
+import { version } from './package.json'
 
-const withIosHiddenSplashStatusBar: ConfigPlugin = (config) => {
-  return withInfoPlist(config, (config) => {
-    config.modResults.UIStatusBarHidden = true
-
-    // ! The forced light content didn't seem to get applied correctly.
-    // ! Maybe has to do with the native code template overriding it somewhere?
-    // config.modResults.UIStatusBarStyle = "UIStatusBarStyleLightContent"
-    // config.modResults.UIViewControllerBasedStatusBarAppearance = false
-
-    return config
-  })
-}
-
-const BUILD_NUMBER = 2
+const BUILD_NUMBER = 2;
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
-  name: "Chain React App 2023",
-  slug: "ChainReactApp2023",
+  name: 'Chain React App 2023',
+  slug: 'ChainReactApp2023',
   version,
-  orientation: "portrait",
-  icon: "./assets/images/app-icon-all.png",
+  orientation: 'portrait',
+  icon: './assets/images/app-icon-all.png',
   splash: {
-    image: "./assets/images/splash-logo-all.png",
-    resizeMode: "contain",
-    backgroundColor: "#081828",
+    image: './assets/images/splash-logo-all.png',
+    resizeMode: 'contain',
+    backgroundColor: '#081828'
   },
   updates: {
-    fallbackToCacheTimeout: 0,
+    fallbackToCacheTimeout: 0
   },
-  jsEngine: "hermes",
-  assetBundlePatterns: ["**/*"],
+  jsEngine: 'hermes',
+  assetBundlePatterns: ['**/*'],
   android: {
-    icon: "./assets/images/app-icon-android-legacy.png",
-    package: "com.chainreactapp",
+    icon: './assets/images/app-icon-android-legacy.png',
+    package: 'com.chainreactapp',
     versionCode: BUILD_NUMBER,
     adaptiveIcon: {
-      foregroundImage: "./assets/images/app-icon-android-adaptive-foreground.png",
-      backgroundImage: "./assets/images/app-icon-android-adaptive-background.png",
+      foregroundImage: './assets/images/app-icon-android-adaptive-foreground.png',
+      backgroundImage: './assets/images/app-icon-android-adaptive-background.png'
     },
     splash: {
-      image: "./assets/images/splash-logo-android-universal.png",
-      resizeMode: "contain",
-      backgroundColor: "#081828",
+      image: './assets/images/splash-logo-android-universal.png',
+      resizeMode: 'contain',
+      backgroundColor: '#081828'
     },
-    googleServicesFile: `./google-services.json`,
+    googleServicesFile: `./google-services.json`
   },
   ios: {
-    icon: "./assets/images/app-icon-ios.png",
+    icon: './assets/images/app-icon-ios.png',
     supportsTablet: true,
-    bundleIdentifier: "infinitered.stage.ChainReactConf",
+    bundleIdentifier: 'infinitered.stage.ChainReactConf',
     buildNumber: String(BUILD_NUMBER),
     splash: {
-      image: "./assets/images/splash-logo-ios-mobile.png",
-      tabletImage: "./assets/images/splash-logo-ios-tablet.png",
-      resizeMode: "contain",
-      backgroundColor: "#081828",
+      image: './assets/images/splash-logo-ios-mobile.png',
+      tabletImage: './assets/images/splash-logo-ios-tablet.png',
+      resizeMode: 'contain',
+      backgroundColor: '#081828'
     },
     googleServicesFile: `./GoogleService-Info.plist`,
+    infoPlist: { UIStatusBarHidden: true },
   },
   web: {
-    favicon: "./assets/images/app-icon-web-favicon.png",
+    favicon: './assets/images/app-icon-web-favicon.png',
     splash: {
-      image: "./assets/images/splash-logo-web.png",
-      resizeMode: "contain",
-      backgroundColor: "#081828",
-    },
+      image: './assets/images/splash-logo-web.png',
+      resizeMode: 'contain',
+      backgroundColor: '#081828'
+    }
   },
-  owner: "infinitered",
+  owner: 'infinitered',
   extra: {
     eas: {
-      projectId: "b72c79d7-7c87-4aa7-b964-998dcff69e07",
+      projectId: 'b72c79d7-7c87-4aa7-b964-998dcff69e07'
     },
-    webflowToken: "63eb6ae43b109a57f2f18438a50a2a91887f53dc238c700b332b0379e74cf616",
+    webflowToken: "63eb6ae43b109a57f2f18438a50a2a91887f53dc238c700b332b0379e74cf616"
   },
   plugins: [
-    "@react-native-firebase/app",
-    "@react-native-firebase/crashlytics",
-    ["expo-build-properties", { ios: { useFrameworks: "static" } }],
-    withIosHiddenSplashStatusBar,
-  ],
-})
+    '@react-native-firebase/app',
+    '@react-native-firebase/crashlytics',
+    ['expo-build-properties', { ios: { useFrameworks: 'static' } }]
+  ]
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,71 +1,86 @@
-import { ExpoConfig, ConfigContext } from '@expo/config';
-import { version } from './package.json'
+import { ExpoConfig, ConfigContext } from "@expo/config"
+import { ConfigPlugin, withInfoPlist } from "expo/config-plugins"
+import { version } from "./package.json"
 
-const BUILD_NUMBER = 2;
+const withIosHiddenSplashStatusBar: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults.UIStatusBarHidden = true
+
+    // ! The forced light content didn't seem to get applied correctly.
+    // ! Maybe has to do with the native code template overriding it somewhere?
+    // config.modResults.UIStatusBarStyle = "UIStatusBarStyleLightContent"
+    // config.modResults.UIViewControllerBasedStatusBarAppearance = false
+
+    return config
+  })
+}
+
+const BUILD_NUMBER = 2
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
-  name: 'Chain React App 2023',
-  slug: 'ChainReactApp2023',
+  name: "Chain React App 2023",
+  slug: "ChainReactApp2023",
   version,
-  orientation: 'portrait',
-  icon: './assets/images/app-icon-all.png',
+  orientation: "portrait",
+  icon: "./assets/images/app-icon-all.png",
   splash: {
-    image: './assets/images/splash-logo-all.png',
-    resizeMode: 'contain',
-    backgroundColor: '#081828'
+    image: "./assets/images/splash-logo-all.png",
+    resizeMode: "contain",
+    backgroundColor: "#081828",
   },
   updates: {
-    fallbackToCacheTimeout: 0
+    fallbackToCacheTimeout: 0,
   },
-  jsEngine: 'hermes',
-  assetBundlePatterns: ['**/*'],
+  jsEngine: "hermes",
+  assetBundlePatterns: ["**/*"],
   android: {
-    icon: './assets/images/app-icon-android-legacy.png',
-    package: 'com.chainreactapp',
+    icon: "./assets/images/app-icon-android-legacy.png",
+    package: "com.chainreactapp",
     versionCode: BUILD_NUMBER,
     adaptiveIcon: {
-      foregroundImage: './assets/images/app-icon-android-adaptive-foreground.png',
-      backgroundImage: './assets/images/app-icon-android-adaptive-background.png'
+      foregroundImage: "./assets/images/app-icon-android-adaptive-foreground.png",
+      backgroundImage: "./assets/images/app-icon-android-adaptive-background.png",
     },
     splash: {
-      image: './assets/images/splash-logo-android-universal.png',
-      resizeMode: 'contain',
-      backgroundColor: '#081828'
+      image: "./assets/images/splash-logo-android-universal.png",
+      resizeMode: "contain",
+      backgroundColor: "#081828",
     },
-    googleServicesFile: `./google-services.json`
+    googleServicesFile: `./google-services.json`,
   },
   ios: {
-    icon: './assets/images/app-icon-ios.png',
+    icon: "./assets/images/app-icon-ios.png",
     supportsTablet: true,
-    bundleIdentifier: 'infinitered.stage.ChainReactConf',
+    bundleIdentifier: "infinitered.stage.ChainReactConf",
     buildNumber: String(BUILD_NUMBER),
     splash: {
-      image: './assets/images/splash-logo-ios-mobile.png',
-      tabletImage: './assets/images/splash-logo-ios-tablet.png',
-      resizeMode: 'contain',
-      backgroundColor: '#081828'
+      image: "./assets/images/splash-logo-ios-mobile.png",
+      tabletImage: "./assets/images/splash-logo-ios-tablet.png",
+      resizeMode: "contain",
+      backgroundColor: "#081828",
     },
-    googleServicesFile: `./GoogleService-Info.plist`
+    googleServicesFile: `./GoogleService-Info.plist`,
   },
   web: {
-    favicon: './assets/images/app-icon-web-favicon.png',
+    favicon: "./assets/images/app-icon-web-favicon.png",
     splash: {
-      image: './assets/images/splash-logo-web.png',
-      resizeMode: 'contain',
-      backgroundColor: '#081828'
-    }
+      image: "./assets/images/splash-logo-web.png",
+      resizeMode: "contain",
+      backgroundColor: "#081828",
+    },
   },
-  owner: 'infinitered',
+  owner: "infinitered",
   extra: {
     eas: {
-      projectId: 'b72c79d7-7c87-4aa7-b964-998dcff69e07'
+      projectId: "b72c79d7-7c87-4aa7-b964-998dcff69e07",
     },
-    webflowToken: "63eb6ae43b109a57f2f18438a50a2a91887f53dc238c700b332b0379e74cf616"
+    webflowToken: "63eb6ae43b109a57f2f18438a50a2a91887f53dc238c700b332b0379e74cf616",
   },
   plugins: [
-    '@react-native-firebase/app',
-    '@react-native-firebase/crashlytics',
-    ['expo-build-properties', { ios: { useFrameworks: 'static' } }]
-  ]
-});
+    "@react-native-firebase/app",
+    "@react-native-firebase/crashlytics",
+    ["expo-build-properties", { ios: { useFrameworks: "static" } }],
+    withIosHiddenSplashStatusBar,
+  ],
+})


### PR DESCRIPTION
# Description

The iOS status bar is by default dark text during splash start up, it doesn't convert over to the light color until the app actually starts and the status bar props are set.

I attempted to set the proper Info.plist value to have the light content at app start, however it didn't take.

This PR hides the status bar content (the dark text) during the initial splash screen and will get set properly to light content when the app begins. This will give it a more polished look than having hard to read dark text switch over to light text mid way through.

This is achieved by using the infoPlist key

or could have been done via config plugin too:

Config plugin (although unnecessary) for reference:
![image](https://user-images.githubusercontent.com/374022/208479470-8f21e1a5-a748-4e00-a813-a884d7f2d5bc.png)


