### PR TITLE
fix: remove scroll indicator and set max font scaling

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -31,7 +31,7 @@ export interface ButtonProps extends PressableProps {
   /**
    * Optional props to pass to the Text
    */
-  textProps?: RNTextProps
+  TextProps?: RNTextProps
   /**
    * Optional options to pass to i18n. Useful for interpolation
    * as well as explicitly setting locale or translation fallbacks.
@@ -83,7 +83,7 @@ export function Button(props: ButtonProps) {
   const {
     tx,
     text,
-    textProps,
+    TextProps,
     txOptions,
     style: $viewStyleOverride,
     pressedStyle: $pressedViewStyleOverride,
@@ -125,7 +125,7 @@ export function Button(props: ButtonProps) {
               text={text}
               txOptions={txOptions}
               style={$textStyle(state)}
-              {...textProps}
+              {...TextProps}
             >
               {children}
             </Text>

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -7,6 +7,7 @@ import {
   TextStyle,
   View,
   ViewStyle,
+  TextProps as RNTextProps,
 } from "react-native"
 import { colors, spacing, typography } from "../theme"
 import { Text, TextProps } from "./Text"
@@ -27,6 +28,10 @@ export interface ButtonProps extends PressableProps {
    * The text to display if not using `tx` or nested components.
    */
   text?: TextProps["text"]
+  /**
+   * Optional props to pass to the Text
+   */
+  textProps?: RNTextProps
   /**
    * Optional options to pass to i18n. Useful for interpolation
    * as well as explicitly setting locale or translation fallbacks.
@@ -78,6 +83,7 @@ export function Button(props: ButtonProps) {
   const {
     tx,
     text,
+    textProps,
     txOptions,
     style: $viewStyleOverride,
     pressedStyle: $pressedViewStyleOverride,
@@ -114,7 +120,13 @@ export function Button(props: ButtonProps) {
               <LeftAccessory style={$leftAccessoryStyle} pressableState={state} />
             )}
 
-            <Text tx={tx} text={text} txOptions={txOptions} style={$textStyle(state)}>
+            <Text
+              tx={tx}
+              text={text}
+              txOptions={txOptions}
+              style={$textStyle(state)}
+              {...textProps}
+            >
               {children}
             </Text>
 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -191,6 +191,7 @@ export function Header(props: HeaderProps) {
 
         {!!titleContent && (
           <Text
+            maxFontSizeMultiplier={3}
             preset="navHeader"
             text={titleContent}
             style={[

--- a/app/navigators/TabNavigator.tsx
+++ b/app/navigators/TabNavigator.tsx
@@ -75,6 +75,7 @@ export function TabNavigator() {
         tabBarInactiveTintColor: colors.text,
         tabBarLabelStyle: $tabBarLabel,
         tabBarItemStyle: $tabBarItem,
+        tabBarAllowFontScaling: false,
       }}
     >
       {screens.map((screen) => (

--- a/app/screens/InfoScreen.tsx
+++ b/app/screens/InfoScreen.tsx
@@ -30,7 +30,7 @@ export const InfoScreen: React.FunctionComponent<TabScreenProps<"Info">> = () =>
         text="Contact"
         onPress={contactByEmail}
         style={$emailButton}
-        textProps={{ maxFontSizeMultiplier: 1.8 }}
+        TextProps={{ maxFontSizeMultiplier: 1.8 }}
       />
     ),
   })

--- a/app/screens/InfoScreen.tsx
+++ b/app/screens/InfoScreen.tsx
@@ -1,5 +1,13 @@
 import React from "react"
-import { ImageStyle, TextStyle, View, ViewStyle, ImageSourcePropType, Image } from "react-native"
+import {
+  ImageStyle,
+  TextStyle,
+  View,
+  ViewStyle,
+  ImageSourcePropType,
+  Image,
+  Text as RNText,
+} from "react-native"
 import { Button, Screen, Text } from "../components"
 import { useHeader } from "../hooks"
 import { TabScreenProps } from "../navigators/TabNavigator"
@@ -25,7 +33,9 @@ export const InfoScreen: React.FunctionComponent<TabScreenProps<"Info">> = () =>
   useHeader({
     title: translate("infoScreen.title"),
     RightActionComponent: (
-      <Button preset="link" text="Contact" onPress={contactByEmail} style={$emailButton} />
+      <Button preset="link" onPress={contactByEmail} style={$emailButton}>
+        <RNText maxFontSizeMultiplier={1.8}>Contact</RNText>
+      </Button>
     ),
   })
 

--- a/app/screens/InfoScreen.tsx
+++ b/app/screens/InfoScreen.tsx
@@ -1,13 +1,5 @@
 import React from "react"
-import {
-  ImageStyle,
-  TextStyle,
-  View,
-  ViewStyle,
-  ImageSourcePropType,
-  Image,
-  Text as RNText,
-} from "react-native"
+import { ImageStyle, TextStyle, View, ViewStyle, ImageSourcePropType, Image } from "react-native"
 import { Button, Screen, Text } from "../components"
 import { useHeader } from "../hooks"
 import { TabScreenProps } from "../navigators/TabNavigator"
@@ -33,9 +25,13 @@ export const InfoScreen: React.FunctionComponent<TabScreenProps<"Info">> = () =>
   useHeader({
     title: translate("infoScreen.title"),
     RightActionComponent: (
-      <Button preset="link" onPress={contactByEmail} style={$emailButton}>
-        <RNText maxFontSizeMultiplier={1.8}>Contact</RNText>
-      </Button>
+      <Button
+        preset="link"
+        text="Contact"
+        onPress={contactByEmail}
+        style={$emailButton}
+        textProps={{ maxFontSizeMultiplier: 1.8 }}
+      />
     ),
   })
 

--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -37,7 +37,9 @@ const AnimatedDayButton = React.forwardRef(
 
     return (
       <Pressable {...{ ref, onPress }} style={$buttonStyle}>
-        <Animated.Text style={[$textStyle, $animatedTextStyle]}>{text}</Animated.Text>
+        <Animated.Text maxFontSizeMultiplier={2} style={[$textStyle, $animatedTextStyle]}>
+          {text}
+        </Animated.Text>
       </Pressable>
     )
   },

--- a/app/screens/VenueScreen/VenueScreen.tsx
+++ b/app/screens/VenueScreen/VenueScreen.tsx
@@ -120,6 +120,7 @@ export const VenueScreen: FC<TabScreenProps<"Venue">> = () => {
   return (
     <Screen style={$root} preset="fixed">
       <SectionList
+        showsVerticalScrollIndicator={false}
         stickySectionHeadersEnabled={false}
         sections={SECTIONS}
         renderSectionHeader={({ section: { title } }) => (

--- a/app/screens/WelcomeScreen.tsx
+++ b/app/screens/WelcomeScreen.tsx
@@ -50,7 +50,7 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = (_props) => {
           <Button
             testID="see-the-schedule-button"
             tx="welcomeScreen.scheduleButton"
-            textProps={{ allowFontScaling: false }}
+            TextProps={{ allowFontScaling: false }}
             onPress={goNext}
           />
         </View>

--- a/app/screens/WelcomeScreen.tsx
+++ b/app/screens/WelcomeScreen.tsx
@@ -25,13 +25,24 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = (_props) => {
       </View>
       <View style={$middleContainer}>
         <Text
+          maxFontSizeMultiplier={1.2}
           testID="welcome-heading"
           style={$welcomeHeading}
           tx="welcomeScreen.heading"
           preset="welcomeHeading"
         />
-        <Text tx="welcomeScreen.topBlurb" preset="companionHeading" style={$topBlurb} />
-        <Text tx="welcomeScreen.bottomBlurb" preset="companionHeading" />
+        <Text
+          maxFontSizeMultiplier={1.2}
+          tx="welcomeScreen.topBlurb"
+          preset="companionHeading"
+          style={$topBlurb}
+        />
+
+        <Text
+          maxFontSizeMultiplier={1.2}
+          tx="welcomeScreen.bottomBlurb"
+          preset="companionHeading"
+        />
       </View>
 
       <SafeAreaView style={$bottomContainer} edges={["bottom"]}>
@@ -39,6 +50,7 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = (_props) => {
           <Button
             testID="see-the-schedule-button"
             tx="welcomeScreen.scheduleButton"
+            textProps={{ allowFontScaling: false }}
             onPress={goNext}
           />
         </View>


### PR DESCRIPTION
# Description

Trello Card:
65-bug-large-font-size-breaks-styles-on-ios
66-bug-venuescreen-scrollbar-too-far-in-from-the-side

Summary of the changes and any helpful notes for reviewers and testers. 

- removes the vertical scroll indicator in the venue screen
- fixes broken styles with larger font sizes on iOS

# Graphics

| Before | After |
| ------ | ------- |
|<img width="300" alt="CleanShot 2022-12-19 at 15 37 23@2x" src="https://user-images.githubusercontent.com/53795920/208540322-b5fa1f6a-cd87-49c7-b721-9f71042b8448.png">|<img width="300" src="https://user-images.githubusercontent.com/53795920/208539789-f333b66e-0429-45bf-aca3-344c74a34229.png">|
|<img width="300" alt="CleanShot 2022-12-19 at 15 37 36@2x" src="https://user-images.githubusercontent.com/53795920/208540413-a772fab9-8273-4c45-9867-73149b6e58e6.png">|<img width="300" src="https://user-images.githubusercontent.com/53795920/208540585-6fe10f38-99d2-4ad4-aa68-663de9436945.png">|


# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features 
- [ ] I have run tests and linter
