### PR TITLE
fix bounce animation: stop over scroll from happening

### DIFF
--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -57,6 +57,7 @@ export function Carousel(props: CarouselProps) {
         {...{ data, onScroll }}
         horizontal
         pagingEnabled
+        overScrollMode="never"
         keyExtractor={(_, index) => `info-image-${index}`}
         bounces={false}
         showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
# Description

Stop over scroll from happening on Android so native on end bounce does not happen

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ![CleanShot 2023-01-13 at 12 19 53](https://user-images.githubusercontent.com/7799266/212391698-893bf54b-c822-45b2-b513-ec600be1a4fe.gif) | ![CleanShot 2023-01-13 at 12 17 36](https://user-images.githubusercontent.com/7799266/212391356-6d2bd4e6-2c00-4df4-bf73-3686df14ec94.gif) |

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
