### PR TITLE
(fix): make CI builds internal distribution instead of app store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Build on EAS
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: eas build --platform all --non-interactive --clear-cache
+        run: eas build --platform all --profile preview:device --non-interactive --clear-cache


### PR DESCRIPTION
# Description

Change PR merge builds to internal distribution (for ease of testing amongst the team)

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
