### PR TITLE
carousel with an even split between items

### DIFF
--- a/app/components/ButtonLink.tsx
+++ b/app/components/ButtonLink.tsx
@@ -5,7 +5,7 @@ import { spacing } from "../theme"
 
 type Props = {
   children: string
-  style: ViewStyle
+  style?: ViewStyle
   openLink: string | ((event: GestureResponderEvent) => void)
 }
 

--- a/app/components/CarouselCard.tsx
+++ b/app/components/CarouselCard.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import {
   GestureResponderEvent,
   ImageSourcePropType,
+  ImageStyle,
   TextStyle,
   View,
   ViewStyle,
@@ -9,7 +10,7 @@ import {
 import { ButtonLink, Text } from "../components"
 import { spacing } from "../theme"
 import Animated, { interpolate, SharedValue, useAnimatedStyle } from "react-native-reanimated"
-import { CAROUSEL_IMAGE_WIDTH, DynamicCarouselItem } from "./Carousel"
+import { CAROUSEL_IMAGE_WIDTH, DynamicCarouselItem, SPACING } from "./Carousel"
 
 export type CarouselCardProps = {
   item: ImageSourcePropType | DynamicCarouselItem
@@ -32,15 +33,14 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
   scrollX,
   leftButton,
   rightButton,
-  totalCardCount,
 }) => {
   const { subtitle, meta, body, image } = item as DynamicCarouselItem
   const source = subtitle ? image : item
 
   const inputRange = [
+    (index - 2) * CAROUSEL_IMAGE_WIDTH,
     (index - 1) * CAROUSEL_IMAGE_WIDTH,
     index * CAROUSEL_IMAGE_WIDTH,
-    (index + 1) * CAROUSEL_IMAGE_WIDTH,
   ]
 
   const $animatedImage = useAnimatedStyle(() => {
@@ -48,32 +48,25 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
     return { transform: [{ scale }] }
   })
 
-  const $imageStyle = { width: CAROUSEL_IMAGE_WIDTH - spacing.medium }
-
   const $animatedSlideData = useAnimatedStyle(() => {
     const translateX = interpolate(scrollX.value, inputRange, [
       CAROUSEL_IMAGE_WIDTH,
-      0 - index * spacing.medium,
+      spacing.medium,
       -CAROUSEL_IMAGE_WIDTH,
     ])
 
-    // * To get the text container underneath to line up correctly, we have to do some
-    // * margin fixing based on first, middle or last slides
-    const marginEndAdjustment =
-      index > 0 ? (index === totalCardCount - 1 ? spacing.medium : spacing.extraSmall) : 0
-
     return {
-      transform: [{ translateX: translateX - marginEndAdjustment }],
+      transform: [{ translateX }],
     }
   })
 
   return (
-    <View>
+    <View style={$carouselCard}>
       <View style={$cardWrapper}>
-        <Animated.Image source={source} style={[$imageStyle, $animatedImage]} />
+        <Animated.Image source={source} style={[$image, $animatedImage]} />
       </View>
       {!!subtitle && (
-        <View style={[{ width: CAROUSEL_IMAGE_WIDTH - spacing.medium }, $slideWrapper]}>
+        <View style={[{ width: CAROUSEL_IMAGE_WIDTH }, $slideWrapper]}>
           {!!meta && (
             <AnimatedText preset="primaryLabel" text={meta} style={[$meta, $animatedSlideData]} />
           )}
@@ -98,19 +91,23 @@ type LinkProps = {
 }
 
 const Link: React.FunctionComponent<LinkProps> = ({ openLink, text }) => {
-  return (
-    <ButtonLink openLink={openLink} style={$carouselCardLink}>
-      {text}
-    </ButtonLink>
-  )
+  return <ButtonLink openLink={openLink}>{text}</ButtonLink>
 }
 
 CarouselCard.Link = Link
 
+const $carouselCard: ViewStyle = {
+  width: CAROUSEL_IMAGE_WIDTH,
+}
+
 const $cardWrapper: ViewStyle = {
   overflow: "hidden",
   borderRadius: 4,
-  marginEnd: spacing.extraSmall,
+  marginHorizontal: SPACING,
+}
+
+const $image: ImageStyle = {
+  width: CAROUSEL_IMAGE_WIDTH,
 }
 
 const $mb: TextStyle = {
@@ -126,11 +123,6 @@ const $ctaContainer: ViewStyle = {
   marginTop: spacing.medium,
 }
 
-const $carouselCardLink: ViewStyle = {
-  marginEnd: spacing.large,
-}
-
 const $slideWrapper: ViewStyle = {
   marginTop: spacing.medium,
-  paddingStart: spacing.medium,
 }


### PR DESCRIPTION
# Description
Carousel should now scale to any amount of Carousel Items

Summary of the changes and any helpful notes for reviewers and testers.

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ![CleanShot 2023-01-18 at 09 48 48](https://user-images.githubusercontent.com/7799266/213258668-56c57edb-6e53-4ca6-925d-84190b9b9248.gif) | ![CleanShot 2023-01-18 at 09 50 14](https://user-images.githubusercontent.com/7799266/213258602-c1e0d2e5-d682-4c12-9071-abc4fb05dd7f.gif) |

# Checklist:




- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
