### PR TITLE
Replace nav header with current date

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -28,10 +28,9 @@ export interface Schedule {
 const { width } = Dimensions.get("window")
 
 export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
-  useHeader({ title: "Schedule" })
-
   const schedules = createScheduleScreenData()
   const [selectedSchedule, setSelectedSchedule] = React.useState<Schedule>(schedules[0])
+  useHeader({ title: formatDate(selectedSchedule.date, "EE, MMMM dd") }, [selectedSchedule])
   const getScheduleIndex = React.useCallback(
     () => schedules.findIndex((schedule) => schedule.date === selectedSchedule.date),
     [schedules, selectedSchedule],
@@ -151,12 +150,6 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
             <View style={[$container, { width }]}>
               <FlashList
                 ref={scheduleListRefs[schedule.date]}
-                ListHeaderComponent={
-                  <View style={$headingContainer}>
-                    <Text preset="screenHeading">{formatDate(schedule.date, "EE, MMMM dd")}</Text>
-                    <Text style={$subheading}>{schedule.title}</Text>
-                  </View>
-                }
                 data={schedule.events}
                 renderItem={({ item }: { item: ScheduleCardProps }) => {
                   const { time, endTime, eventTitle, heading, subheading, sources, level, id } =

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { View, TextStyle, ViewStyle, Dimensions } from "react-native"
+import { View, ViewStyle, Dimensions } from "react-native"
 import { ContentStyle, FlashList } from "@shopify/flash-list"
 import Animated, {
   useAnimatedScrollHandler,
@@ -7,7 +7,6 @@ import Animated, {
   runOnJS,
 } from "react-native-reanimated"
 import { useIsFocused } from "@react-navigation/native"
-import { Text } from "../../components"
 import { TabScreenProps } from "../../navigators/TabNavigator"
 import { colors, spacing } from "../../theme"
 import { useHeader } from "../../hooks/useHeader"
@@ -204,19 +203,11 @@ const $container: ViewStyle = {
   paddingHorizontal: spacing.large,
 }
 
-const $subheading: TextStyle = {
-  color: colors.palette.primary500,
-}
-
 const $list: ContentStyle = {
   paddingTop: spacing.extraLarge,
   paddingBottom: 48 + spacing.medium,
 }
 
 const $cardContainer: ViewStyle = {
-  paddingBottom: spacing.large,
-}
-
-const $headingContainer: ViewStyle = {
   paddingBottom: spacing.large,
 }


### PR DESCRIPTION
# Description
Replace nav header with the current schedule index date

Summary of the changes and any helpful notes for reviewers and testers.

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ![CleanShot 2023-01-19 at 14 22 21](https://user-images.githubusercontent.com/7799266/213552231-ae9dca3e-ad69-40e7-baaa-f9547f1a4d36.gif) | ![CleanShot 2023-01-19 at 14 21 31](https://user-images.githubusercontent.com/7799266/213552176-2ed0f75a-dd78-4152-8d11-064221da4895.gif) |

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
