### PR TITLE
feat: change card styles to indicate past events

### DIFF
--- a/app/components/BoxShadow.tsx
+++ b/app/components/BoxShadow.tsx
@@ -72,6 +72,22 @@ const $offsetPresets = {
     },
   ] as StyleProp<ImageStyle>,
 
+  secondary: [
+    {
+      tintColor: colors.palette.secondary500,
+      borderColor: colors.palette.neutral300,
+      borderWidth: 1,
+    },
+  ] as StyleProp<ImageStyle>,
+
+  reversed: [
+    {
+      borderColor: colors.palette.neutral300,
+      borderWidth: 1,
+      tintColor: colors.palette.neutral300,
+    },
+  ] as StyleProp<ImageStyle>,
+
   bold: [
     {
       backgroundColor: colors.palette.bold500,

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -186,7 +186,17 @@ export function Card(props: CardProps) {
   ]
 
   return (
-    <BoxShadow preset={preset === "default" ? "primary" : "default"}>
+    <BoxShadow
+      preset={
+        preset === "default"
+          ? "primary"
+          : preset === "pastDefault"
+          ? "secondary"
+          : preset === "pastReversed"
+          ? "reversed"
+          : "default"
+      }
+    >
       <Wrapper
         style={$containerStyle}
         activeOpacity={0.8}
@@ -274,19 +284,35 @@ const $containerPresets = {
     $containerBase,
     { backgroundColor: colors.palette.primary100, borderColor: colors.palette.primary500 },
   ] as StyleProp<ViewStyle>,
+
+  pastDefault: [
+    $containerBase,
+    { backgroundColor: colors.palette.neutral500, borderColor: colors.palette.neutral300 },
+  ] as StyleProp<ViewStyle>,
+
+  pastReversed: [
+    $containerBase,
+    { backgroundColor: colors.palette.neutral300, borderColor: colors.palette.neutral300 },
+  ] as StyleProp<ViewStyle>,
 }
 
 const $headingPresets: Record<Presets, TextStyle> = {
   default: {},
   reversed: { color: colors.palette.neutral100 },
+  pastDefault: {},
+  pastReversed: {},
 }
 
 const $contentPresets: Record<Presets, TextStyle> = {
   default: {},
   reversed: { color: colors.palette.neutral100 },
+  pastDefault: {},
+  pastReversed: {},
 }
 
 const $footerPresets: Record<Presets, TextStyle> = {
   default: {},
   reversed: { color: colors.palette.neutral100 },
+  pastDefault: {},
+  pastReversed: {},
 }

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -190,20 +190,16 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
         }
       : baseSpeakingEventProps({ heading, subheading, eventTitle, sources, isPast })
 
-  return (
-    <Card
-      preset={
-        isPast
-          ? variant === "recurring" || variant === "party"
-            ? "pastReversed"
-            : "pastDefault"
-          : variant === "recurring" || variant === "party"
-          ? "reversed"
-          : "default"
-      }
-      {...{ ...cardProps, ...variantProps, onPress }}
-    />
-  )
+  const isReversed = variant === "recurring" || variant === "party"
+  const cardPreset = isReversed
+    ? isPast
+      ? "pastReversed"
+      : "reversed"
+    : isPast
+    ? "pastDefault"
+    : "default"
+
+  return <Card preset={cardPreset} {...{ ...cardProps, ...variantProps, onPress }} />
 }
 
 const $avatar: ViewStyle = {

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -6,33 +6,35 @@ import { useAppNavigation } from "../../hooks"
 
 interface HeaderProps {
   endTime?: string
-  time: string
+  formattedStartTime: string
   title: string
+  isPast?: boolean
 }
 
 interface FooterProps {
   heading: string
   subheading: string
+  isPast?: boolean
 }
 
-const Header = ({ endTime, time, title }: HeaderProps) => (
+const Header = ({ endTime, formattedStartTime, title, isPast }: HeaderProps) => (
   <View style={$headerContainer}>
-    <Text style={$timeText}>
-      {time}
+    <Text style={isPast ? $pastTimeText : $timeText}>
+      {formattedStartTime}
       {!!endTime && ` - ${endTime}`}
     </Text>
-    <Text preset="eventTitle" style={$titleText}>
+    <Text preset="eventTitle" style={isPast ? $pastTitleText : $titleText}>
       {title}
     </Text>
   </View>
 )
 
-const Footer = ({ heading, subheading }: FooterProps) => (
+const Footer = ({ heading, subheading, isPast }: FooterProps) => (
   <View style={$footerContainer}>
-    <Text preset="cardFooterHeading" style={$footerHeading}>
+    <Text preset="cardFooterHeading" style={isPast ? $pastFooterHeading : $footerHeading}>
       {heading}
     </Text>
-    <Text style={$footerSubheading}>{subheading}</Text>
+    <Text style={isPast ? $pastFooterSubheading : $footerSubheading}>{subheading}</Text>
   </View>
 )
 
@@ -46,9 +48,13 @@ export interface ScheduleCardProps {
    */
   variant?: Variants
   /**
+   * Start time of the event formatted as "hh:mm aaa"
+   */
+  formattedStartTime: string
+  /**
    * Start time of the event
    */
-  time: string
+  startTime?: string
   /**
    * End time of the recurring event
    */
@@ -77,6 +83,10 @@ export interface ScheduleCardProps {
    * Card ID
    */
   id: string
+  /**
+   * Whether the event is in the past
+   */
+  isPast?: boolean
 }
 
 interface SpeakingEventProps {
@@ -84,19 +94,30 @@ interface SpeakingEventProps {
   subheading: string
   eventTitle: string
   sources: string[]
+  isPast?: boolean
+  startTime?: string
 }
 
 interface BaseEventProps {
-  time: string
+  formattedStartTime: string
   endTime?: string
   eventTitle: string
   level?: string
+  isPast?: boolean
+  date?: string
 }
 
-const baseEventProps = ({ time, endTime, eventTitle, level }: BaseEventProps) => {
+const baseEventProps = ({
+  formattedStartTime,
+  endTime,
+  eventTitle,
+  level,
+  isPast,
+  date,
+}: BaseEventProps) => {
   const title = `${level ? `${level} ` : ""}${eventTitle}`
   return {
-    HeadingComponent: <Header {...{ time, endTime, title }} />,
+    HeadingComponent: <Header {...{ formattedStartTime, endTime, title, isPast, date }} />,
   }
 }
 
@@ -105,6 +126,8 @@ const baseSpeakingEventProps = ({
   subheading,
   eventTitle,
   sources = [],
+  isPast,
+  startTime,
 }: SpeakingEventProps) => {
   const props = {
     preset: eventTitle,
@@ -122,14 +145,14 @@ const baseSpeakingEventProps = ({
         />
       </View>
     ),
-    FooterComponent: <Footer {...{ heading, subheading }} />,
+    FooterComponent: <Footer {...{ heading, subheading, isPast, startTime }} />,
   }
 }
 
 const ScheduleCard: FC<ScheduleCardProps> = (props) => {
   const {
     variant = "recurring",
-    time,
+    formattedStartTime,
     endTime,
     eventTitle,
     heading,
@@ -137,6 +160,7 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
     sources,
     level,
     id,
+    isPast,
   } = props
   const navigation = useAppNavigation()
   const onPress = ["talk", "workshop"].includes(variant)
@@ -145,14 +169,16 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
     ? () => navigation.navigate("PartyDetails", { scheduleId: id })
     : undefined
 
-  const cardProps = { ...baseEventProps({ time, endTime, eventTitle, level }) }
+  const cardProps = {
+    ...baseEventProps({ formattedStartTime, endTime, eventTitle, level, isPast }),
+  }
   const variantProps =
     variant === "recurring"
-      ? { content: subheading, contentStyle: $contentText }
+      ? { content: subheading, contentStyle: isPast ? $pastContentText : $contentText }
       : variant === "party"
       ? {
           content: subheading,
-          contentStyle: $contentText,
+          contentStyle: isPast ? $pastContentText : $contentText,
           FooterComponent: (
             <Icon
               icon="arrow"
@@ -162,11 +188,19 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
             />
           ),
         }
-      : baseSpeakingEventProps({ heading, subheading, eventTitle, sources })
+      : baseSpeakingEventProps({ heading, subheading, eventTitle, sources, isPast })
 
   return (
     <Card
-      preset={variant === "recurring" || variant === "party" ? "reversed" : "default"}
+      preset={
+        isPast
+          ? variant === "recurring" || variant === "party"
+            ? "pastReversed"
+            : "pastDefault"
+          : variant === "recurring" || variant === "party"
+          ? "reversed"
+          : "default"
+      }
       {...{ ...cardProps, ...variantProps, onPress }}
     />
   )
@@ -182,8 +216,17 @@ const $footerSubheading: TextStyle = {
   color: colors.palette.neutral900,
 }
 
+const $pastFooterSubheading: TextStyle = {
+  color: colors.palette.primary100,
+}
+
 const $timeText: TextStyle = {
   color: colors.palette.neutral900,
+  marginBottom: spacing.large,
+}
+
+const $pastTimeText: TextStyle = {
+  color: colors.palette.primary100,
   marginBottom: spacing.large,
 }
 
@@ -192,13 +235,28 @@ const $titleText: TextStyle = {
   textTransform: "uppercase",
 }
 
+const $pastTitleText: TextStyle = {
+  color: colors.palette.primary100,
+  textTransform: "uppercase",
+}
+
 const $contentText: TextStyle = {
   color: colors.palette.neutral500,
   paddingTop: 10,
 }
 
+const $pastContentText: TextStyle = {
+  color: colors.palette.neutral100,
+  paddingTop: 10,
+}
+
 const $footerHeading: TextStyle = {
   color: colors.palette.neutral900,
+  marginBottom: spacing.extraSmall,
+}
+
+const $pastFooterHeading: TextStyle = {
+  color: colors.palette.primary100,
   marginBottom: spacing.extraSmall,
 }
 

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -169,12 +169,8 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
                       ? () => navigation.navigate("TalkDetails")
                       : undefined
 
-                  // Temporary time for testing. Without this, the isPast check will always return false since the startTime is in the future
-                  const tempTime = "2023-05-18T20:30:00.000Z"
-                  // TODO: Remove tempTime and the line below after testing
-                  const isPast = isBefore(new Date(startTime), new Date(tempTime))
-                  // TODO: Uncomment the line below after testing
-                  // const isPast = isBefore(new Date(startTime), new Date())
+                  const isPast = isBefore(new Date(startTime), new Date())
+
                   return (
                     <View style={$cardContainer}>
                       <ScheduleCard

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -15,7 +15,7 @@ import { ScheduleDayPicker } from "./ScheduleDayPicker"
 import ScheduleCard, { ScheduleCardProps, Variants } from "./ScheduleCard"
 import { formatDate } from "../../utils/formatDate"
 import { useAppNavigation, useAppState } from "../../hooks"
-import { format } from "date-fns"
+import { format, isBefore } from "date-fns"
 
 import { createScheduleScreenData } from "../../services/api/webflow-helpers"
 
@@ -89,7 +89,9 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
     // Scroll to the proper time of day talk
     setTimeout(() => {
       const schedule = schedules[scheduleIndex]
-      const eventIndex = schedule?.events?.findIndex((e) => e.time.startsWith(currentHour))
+      const eventIndex = schedule?.events?.findIndex((e) =>
+        e.formattedStartTime.startsWith(currentHour),
+      )
       if (eventIndex > -1) {
         scheduleListRefs[schedule?.date]?.current?.scrollToIndex({
           animated: true,
@@ -159,18 +161,34 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
                 }
                 data={schedule.events}
                 renderItem={({ item }: { item: ScheduleCardProps }) => {
-                  const { time, endTime, eventTitle, heading, subheading, sources, level, id } =
-                    item
+                  const {
+                    startTime,
+                    formattedStartTime,
+                    endTime,
+                    eventTitle,
+                    heading,
+                    subheading,
+                    sources,
+                    level,
+                    id,
+                  } = item
                   const onPress =
                     item.variant !== "recurring"
                       ? () => navigation.navigate("TalkDetails")
                       : undefined
+
+                  // Temporary time for testing. Without this, the isPast check will always return false since the startTime is in the future
+                  const tempTime = "2023-05-18T20:30:00.000Z"
+                  // TODO: Remove tempTime and the line below after testing
+                  const isPast = isBefore(new Date(startTime), new Date(tempTime))
+                  // TODO: Uncomment the line below after testing
+                  // const isPast = isBefore(new Date(startTime), new Date())
                   return (
                     <View style={$cardContainer}>
                       <ScheduleCard
                         variant={item.variant as Variants}
                         {...{
-                          time,
+                          formattedStartTime,
                           endTime,
                           eventTitle,
                           heading,
@@ -179,6 +197,7 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
                           sources,
                           level,
                           id,
+                          isPast,
                         }}
                       />
                     </View>

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -127,7 +127,11 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
     case "Recurring":
       return {
         variant: "recurring",
-        time: formatDate(schedule["day-time"], schedule["end-time"] ? "h:mm" : "h:mm aaa"),
+        formattedStartTime: formatDate(
+          schedule["day-time"],
+          schedule["end-time"] ? "h:mm" : "h:mm aaa",
+        ),
+        startTime: schedule["day-time"],
         endTime: schedule["end-time"] && formatDate(schedule["end-time"], "h:mm aaa"),
         eventTitle: schedule["recurring-event"]?.name,
         heading: "",
@@ -138,7 +142,8 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
     case "Party":
       return {
         variant: "party",
-        time: formatDate(schedule["day-time"], "h:mm aaa"),
+        formattedStartTime: formatDate(schedule["day-time"], "h:mm aaa"),
+        startTime: schedule["day-time"],
         eventTitle: "party",
         heading: schedule.name,
         subheading: schedule["break-party-description"],
@@ -148,7 +153,8 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
     case "Talk":
       return {
         variant: "talk",
-        time: formatDate(schedule["day-time"], "h:mm aaa"),
+        formattedStartTime: formatDate(schedule["day-time"], "h:mm aaa"),
+        startTime: schedule["day-time"],
         eventTitle: schedule.type,
         heading: schedule.talk?.name,
         subheading: schedule.talk?.description,
@@ -158,7 +164,8 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
     case "Speaker Panel":
       return {
         variant: "talk",
-        time: formatDate(schedule["day-time"], "h:mm aaa"),
+        formattedStartTime: formatDate(schedule["day-time"], "h:mm aaa"),
+        startTime: schedule["day-time"],
         eventTitle: schedule.type,
         heading: schedule.talk?.["speaker-s"]?.map((s) => s.name).join(", ") ?? "",
         subheading: "",
@@ -170,7 +177,8 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
       const workshop = schedule.workshop
       return {
         variant: "workshop",
-        time: formatDate(schedule["day-time"], "h:mm aaa"),
+        formattedStartTime: formatDate(schedule["day-time"], "h:mm aaa"),
+        startTime: schedule["day-time"],
         eventTitle: "workshop",
         heading: workshop?.name,
         subheading: workshop?.["instructor-info"]?.name,


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

[Trello Card](88-update-schedule-card-styles-to-indicate-past-events)

Summary of the changes: 

- Check if the event already happened in the past then change card styles to indicate that is a past event.


# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
|<video width="350" src="https://user-images.githubusercontent.com/53795920/214094970-20ddefe5-f138-45de-b0b7-cd1a999571e1.mp4" />|<video width="350" src="https://user-images.githubusercontent.com/53795920/214099618-0afae4fc-c0d7-4199-a6b3-046091d6dd32.mp4" />|


# Checklist:




- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
