### PR TITLE
Error boundary customization

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -99,12 +99,18 @@ function App(props: AppProps) {
     onNavigationStateChange,
     isRestored: isNavigationStateRestored,
   } = useNavigationPersistence(storage, NAVIGATION_PERSISTENCE_KEY)
-
+  const [recoveredFromError, setRecoveredFromError] = React.useState(false)
   const [areFontsLoaded] = useFonts(customFontsToLoad)
 
   useLayoutEffect(() => {
     // hide splash screen after 500ms
     setTimeout(hideSplashScreen, 500)
+  })
+
+  useLayoutEffect(() => {
+    if (recoveredFromError) {
+      setRecoveredFromError(false)
+    }
   })
 
   // Before we show the app, we have to wait for our state to be ready.
@@ -118,10 +124,10 @@ function App(props: AppProps) {
   // otherwise, we're ready to render the app
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-      <ErrorBoundary catchErrors={Config.catchErrors}>
+      <ErrorBoundary catchErrors={Config.catchErrors} onReset={() => setRecoveredFromError(true)}>
         <QueryClientProvider client={queryClient}>
           <AppNavigator
-            initialState={initialNavigationState}
+            initialState={recoveredFromError ? { index: 0, routes: [] } : initialNavigationState}
             onStateChange={onNavigationStateChange}
           />
           <CustomToast />

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -71,6 +71,10 @@ export interface ButtonProps extends PressableProps {
    * Children components.
    */
   children?: React.ReactNode
+  /**
+   * Styles override for the shadow.
+   */
+  shadowStyle?: StyleProp<ViewStyle>
 }
 
 /**
@@ -89,6 +93,7 @@ export function Button(props: ButtonProps) {
     pressedStyle: $pressedViewStyleOverride,
     textStyle: $textStyleOverride,
     pressedTextStyle: $pressedTextStyleOverride,
+    shadowStyle: $shadowStyleOverride,
     children,
     RightAccessory,
     LeftAccessory,
@@ -110,9 +115,10 @@ export function Button(props: ButtonProps) {
       !!pressed && [$pressedTextPresets[preset], $pressedTextStyleOverride],
     ]
   }
+  const $shadowStyle = [$shadowPresets[preset], $shadowStyleOverride]
 
   return (
-    <View style={$shadowPresets[preset]}>
+    <View style={$shadowStyle}>
       <Pressable style={$viewStyle} accessibilityRole="button" {...rest}>
         {(state) => (
           <>

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -14,7 +14,7 @@ const en = {
   errorScreen: {
     title: "Oh, bother!",
     friendlySubtitle:
-      "Bugs happen to the best of us! Try resetting or restarting the app and see if that helps. If not, feel free to file an issue on GitHub and our team of highly-trained llamas will look into it.",
+      "Bugs happen to the best of us! Try resetting or restarting the app and see if that helps. If not, feel free to file an issue on GitHub and our team of highly-trained llamas will look into it. Bonus points: Find the bug and open a PR!",
     reset: "Reset",
     githubButton: "Go to GitHub",
   },

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -12,10 +12,11 @@ const en = {
     scheduleButton: "See the schedule",
   },
   errorScreen: {
-    title: "Something went wrong!",
+    title: "Oh, bother!",
     friendlySubtitle:
-      "This is the screen that your users will see in production when an error is thrown. You'll want to customize this message (located in `app/i18n/en.ts`) and probably the layout as well (`app/screens/ErrorScreen`). If you want to remove this entirely, check `app/app.tsx` for the <ErrorBoundary> component.",
-    reset: "RESET APP",
+      "Bugs happen to the best of us! Try resetting or restarting the app and see if that helps. If not, feel free to file an issue on GitHub and our team of highly-trained llamas will look into it.",
+    reset: "Reset",
+    githubButton: "Go to GitHub",
   },
   emptyStateComponent: {
     generic: {

--- a/app/screens/ErrorScreen/ErrorBoundary.tsx
+++ b/app/screens/ErrorScreen/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { ErrorDetails } from "./ErrorDetails"
 interface Props {
   children: ReactNode
   catchErrors: "always" | "dev" | "prod" | "never"
+  onReset(): void
 }
 
 interface State {
@@ -38,6 +39,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   // Reset the error back to null
   resetError = () => {
+    this.props.onReset()
     this.setState({ error: null, errorInfo: null })
   }
 

--- a/app/screens/ErrorScreen/ErrorDetails.tsx
+++ b/app/screens/ErrorScreen/ErrorDetails.tsx
@@ -2,6 +2,7 @@ import React, { ErrorInfo } from "react"
 import { ScrollView, TextStyle, View, ViewStyle } from "react-native"
 import { Button, Icon, Screen, Text } from "../../components"
 import { colors, spacing } from "../../theme"
+import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
 
 export interface ErrorDetailsProps {
   error: Error
@@ -10,6 +11,14 @@ export interface ErrorDetailsProps {
 }
 
 export function ErrorDetails(props: ErrorDetailsProps) {
+  const { error, errorInfo } = props
+  const errorTitle = `${error}`.trim()
+  // Issue body that is the first 10 lines of the error stack
+  const issueBodyStacktrace = errorInfo.componentStack.split("\n").slice(0, 10).join("\n")
+  const githubURL = encodeURI(
+    `https://github.com/infinitered/ChainReactApp2023/issues/new?title=(CRASH) ${errorTitle}&body=What were you doing when the app crashed?\n\n\nTruncated Stacktrace:\n\`\`\`${issueBodyStacktrace}\`\`\``,
+  )
+
   return (
     <Screen
       preset="fixed"
@@ -22,16 +31,25 @@ export function ErrorDetails(props: ErrorDetailsProps) {
         <Text tx="errorScreen.friendlySubtitle" />
       </View>
 
+      <Button
+        preset="default"
+        style={$githubButton}
+        shadowStyle={$button}
+        tx="errorScreen.githubButton"
+        onPress={() => openLinkInBrowser(githubURL)}
+      />
+
       <ScrollView style={$errorSection} contentContainerStyle={$errorSectionContentContainer}>
-        <Text style={$errorContent} weight="bold" text={`${props.error}`.trim()} />
-        <Text
-          selectable
-          style={$errorBacktrace}
-          text={`${props.errorInfo.componentStack}`.trim()}
-        />
+        <Text weight="bold" text={`${error}`.trim()} />
+        <Text selectable style={$errorBacktrace} text={`${errorInfo.componentStack}`.trim()} />
       </ScrollView>
 
-      <Button style={$resetButton} onPress={props.onReset} tx="errorScreen.reset" />
+      <Button
+        style={$resetButton}
+        shadowStyle={$button}
+        onPress={props.onReset}
+        tx="errorScreen.reset"
+      />
     </Screen>
   )
 }
@@ -44,19 +62,20 @@ const $contentContainer: ViewStyle = {
 }
 
 const $topSection: ViewStyle = {
-  flex: 1,
   alignItems: "center",
+  marginBottom: spacing.large,
 }
 
 const $heading: TextStyle = {
-  color: colors.error,
+  color: colors.errorBackground,
   marginBottom: spacing.medium,
 }
 
 const $errorSection: ViewStyle = {
   flex: 2,
   backgroundColor: colors.separator,
-  marginVertical: spacing.medium,
+  marginBottom: spacing.medium,
+  marginTop: spacing.large,
   borderRadius: 6,
 }
 
@@ -64,16 +83,21 @@ const $errorSectionContentContainer: ViewStyle = {
   padding: spacing.medium,
 }
 
-const $errorContent: TextStyle = {
-  color: colors.error,
-}
-
 const $errorBacktrace: TextStyle = {
   marginTop: spacing.medium,
   color: colors.textDim,
 }
 
-const $resetButton: ViewStyle = {
+const $button: ViewStyle = {
   backgroundColor: colors.error,
+}
+
+const $resetButton: ViewStyle = {
+  ...$button,
+  paddingHorizontal: spacing.huge,
+}
+
+const $githubButton: ViewStyle = {
+  ...$button,
   paddingHorizontal: spacing.huge,
 }

--- a/app/screens/ErrorScreen/ErrorDetails.tsx
+++ b/app/screens/ErrorScreen/ErrorDetails.tsx
@@ -57,7 +57,7 @@ export function ErrorDetails(props: ErrorDetailsProps) {
 const $contentContainer: ViewStyle = {
   alignItems: "center",
   paddingHorizontal: spacing.large,
-  paddingTop: spacing.extraLarge,
+  paddingVertical: spacing.medium,
   flex: 1,
 }
 
@@ -67,7 +67,6 @@ const $topSection: ViewStyle = {
 }
 
 const $heading: TextStyle = {
-  color: colors.errorBackground,
   marginBottom: spacing.medium,
 }
 


### PR DESCRIPTION

# Description

[Trello Card](27-error-boundary-crash-resilience)

- Spruce up Error Detail screen with fun copy and link to GH with pre-filled issue template
- Fix reset button so it actually resets the navigation state 

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <img width="390" alt="Screen Shot 2023-01-24 at 3 55 34 PM" src="https://user-images.githubusercontent.com/6894653/214447321-eabf9b43-3b0e-49f0-9b16-b06934d1cc44.png">  |  <img width="357" alt="Screen Shot 2023-01-24 at 3 56 37 PM" src="https://user-images.githubusercontent.com/6894653/214447406-b01bb4ca-71ba-4908-8595-5ff761fc26e0.png"> |
| https://user-images.githubusercontent.com/6894653/214446603-594c8a71-65c4-48d8-8085-c2f5a04be23a.mp4 | https://user-images.githubusercontent.com/6894653/214446670-440743bb-25b3-4d4d-b5a7-c2b845323aa1.mp4 |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
