### PR TITLE
fix(schedule): Display ActivityIndicator when schedule is loading

### DIFF
--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -98,12 +98,20 @@ export const cleanedSchedule = ({
     }))
 }
 
+
+type ScheduleList = {
+  isLoading: boolean
+  schedules: Schedule[]
+}
 /*
  * Converting workshop data from "type ids" to "type names"
  */
-export const createScheduleScreenData = (): Schedule[] => {
-  const { data: events } = useScheduledEvents()
-  return [
+export const createScheduleScreenData = (): ScheduleList => {
+  const { data: events, isLoading } = useScheduledEvents()
+
+  return {
+    isLoading,
+    schedules: [
     {
       date: "2023-05-17",
       title: "React Native Workshops",
@@ -119,7 +127,7 @@ export const createScheduleScreenData = (): Schedule[] => {
       title: "Conference Day 2",
       events: convertScheduleToScheduleCard(events, "Friday"),
     },
-  ]
+  ]}
 }
 
 const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps => {


### PR DESCRIPTION
# Description

[Trello Card](89-bug-delay-before-schedule-loads)

Refactor helper to expose `isLoading` when getting schedule data, and use that data to display an `ActivityIndicator` when appropriate.

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <video src="https://user-images.githubusercontent.com/1761481/214731732-6e9cd834-7798-4c4a-8094-534cb05dde6c.mp4" /> | <video src="https://user-images.githubusercontent.com/1761481/214739019-846dd359-6a5f-4a71-9d27-9adf10aab705.mp4" /> |

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
