### PR TITLE
fix: Remove dangling console.tron.log call

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -133,8 +133,6 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
 
   if (!selectedSchedule) return null
 
-  console.tron.log("schedules", schedules)
-
   return (
     <>
       <View style={$root}>


### PR DESCRIPTION
This was mistakenly added in #51 