### PR TITLE
feat(debug): Add Reset State button to debug screen

### DIFF
--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -21,6 +21,7 @@ const en = {
   debugScreen: {
     title: "Debug Info",
     pushToken: "FCM Token",
+    resetState: "Reset App State",
   },
   emptyStateComponent: {
     generic: {

--- a/app/screens/DebugScreen.tsx
+++ b/app/screens/DebugScreen.tsx
@@ -1,13 +1,15 @@
 import React, { FC } from "react"
 import { TextStyle, ViewStyle } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
-import { AppStackParamList } from "../navigators"
-import { HeaderAction, Screen, Text } from "../components"
+import { AppStackParamList, resetRoot } from "../navigators"
+import { Button, HeaderAction, Screen, Text } from "../components"
 
 import messaging from "@react-native-firebase/messaging"
 import { spacing } from "../theme"
 import { useAppNavigation, useHeader } from "../hooks"
 import { translate } from "../i18n"
+import { clear } from "../utils/storage"
+import { useQueryClient } from "@tanstack/react-query"
 
 export const DebugScreen: FC<StackScreenProps<AppStackParamList, "Debug">> = () => {
   const navigation = useAppNavigation()
@@ -16,6 +18,19 @@ export const DebugScreen: FC<StackScreenProps<AppStackParamList, "Debug">> = () 
     title: translate("debugScreen.title"),
   })
   const [fcmToken, setFcmToken] = React.useState<string | null>(null)
+  const queryClient = useQueryClient()
+
+  const clearState = () => {
+    // Clear react-query state
+    queryClient.resetQueries()
+
+    // Clear async storage
+    clear()
+
+    // Clear navigation state
+    resetRoot()
+    navigation.navigate("Welcome")
+  }
 
   React.useEffect(() => {
     const getToken = async () => {
@@ -29,6 +44,11 @@ export const DebugScreen: FC<StackScreenProps<AppStackParamList, "Debug">> = () 
     <Screen style={$root} safeAreaEdges={["bottom"]}>
       <Text preset="bold" tx="debugScreen.pushToken" style={$subtitle} />
       <Text text={fcmToken} selectable />
+      <Button
+        shadowStyle={$resetStateButtonShadow}
+        tx="debugScreen.resetState"
+        onPress={() => clearState()}
+      />
     </Screen>
   )
 }
@@ -36,6 +56,10 @@ export const DebugScreen: FC<StackScreenProps<AppStackParamList, "Debug">> = () 
 const $root: ViewStyle = {
   flex: 1,
   paddingHorizontal: spacing.large,
+}
+
+const $resetStateButtonShadow: ViewStyle = {
+  marginTop: spacing.large,
 }
 
 const $subtitle: TextStyle = {

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -98,7 +98,6 @@ export const cleanedSchedule = ({
     }))
 }
 
-
 type ScheduleList = {
   isLoading: boolean
   schedules: Schedule[]


### PR DESCRIPTION
# Description

[Trello Card](93-add-full-state-reset-to-debug-screen)

Add 'Reset App State' button to clear async storage, reset react-query queries, reset navigation, and go to the welcome screen.

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <video src="https://user-images.githubusercontent.com/1761481/214989249-2ce70618-4cea-457b-89ae-bbd8828d1751.mp4" /> | <video src="https://user-images.githubusercontent.com/1761481/214989383-4b0c7e4c-6ed1-4b8a-a483-5f0c24e2bfbe.mp4" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
