### PR TITLE
feat(ScheduleScreen): source current date from AsyncStorage for debug…

### DIFF
--- a/app/hooks/useCurrentDate.ts
+++ b/app/hooks/useCurrentDate.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+import { loadString } from "../utils/storage"
+
+const isValidDateString = (date: string) => {
+  const d = new Date(date)
+  return d instanceof Date && !isNaN(d.getTime())
+}
+
+/**
+ * Check async storage the `currentDate` key on mount for a valid date value.
+ * If it's not there, or it's not a valid date, then we'll set it to the current date.
+ */
+export function useCurrentDate() {
+  const [currentDate, setCurrentDate] = useState<Date>(new Date())
+
+  useEffect(() => {
+    async function checkCurrentDate() {
+      const date = await loadString("currentDate")
+      if (date && isValidDateString(date)) {
+        setCurrentDate(new Date(date))
+      }
+    }
+    checkCurrentDate()
+  }, [])
+
+  useEffect(() => {
+    console.tron.log("currentDate", currentDate)
+  }, [currentDate])
+
+  return currentDate
+}

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -17,6 +17,7 @@ import { useAppState } from "../../hooks"
 import { format, isAfter } from "date-fns"
 import { createScheduleScreenData } from "../../services/api/webflow-helpers"
 import { ScrollToButton, useScrollToEvent } from "../../components"
+import { useCurrentDate } from "../../hooks/useCurrentDate"
 
 export interface Schedule {
   date: string
@@ -57,7 +58,7 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
     )
   }, [])
 
-  const date = new Date()
+  const date = useCurrentDate()
   const scheduleIndex = getCurrentScheduleIndex(schedules, date)
   const schedule = schedules[scheduleIndex]
   const eventIndex = getCurrentEventIndex(schedule, date)

--- a/app/services/reactotron/reactotron.ts
+++ b/app/services/reactotron/reactotron.ts
@@ -16,7 +16,7 @@ import { Platform } from "react-native"
 import { Reactotron } from "./reactotronClient"
 import { ArgType } from "reactotron-core-client"
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import { clear } from "../../utils/storage"
+import { saveString } from "../../utils/storage"
 import { ReactotronConfig, DEFAULT_REACTOTRON_CONFIG } from "./reactotronConfig"
 import { goBack, resetRoot, navigate, navigationRef } from "../../navigators/navigationUtilities"
 import { fakeReactotron } from "./reactotronFake"
@@ -94,14 +94,28 @@ export function setupReactotron(customConfig: ReactotronConfig = {}) {
      * creativity -- this is great for development to quickly and easily
      * get your app into the state you want.
      */
+
     Reactotron.onCustomCommand({
-      title: "Reset Root Store",
-      description: "Resets the MST store",
-      command: "resetStore",
-      handler: () => {
-        Reactotron.log("resetting store")
-        clear()
+      command: "setCurrentDate",
+      handler: (args) => {
+        const { currentDate } = args
+        ;(async () => {
+          await saveString("currentDate", currentDate)
+        })()
+        if (currentDate) {
+          console.log(`Setting current date: ${currentDate}`)
+        } else {
+          console.log("Could not set current date. No date provided.")
+        }
       },
+      title: "Set Current Date",
+      description: "Set current date for timeline view",
+      args: [
+        {
+          name: "currentDate",
+          type: ArgType.String,
+        },
+      ],
     })
 
     Reactotron.onCustomCommand({

--- a/app/services/reactotron/reactotron.ts
+++ b/app/services/reactotron/reactotron.ts
@@ -109,7 +109,7 @@ export function setupReactotron(customConfig: ReactotronConfig = {}) {
         }
       },
       title: "Set Current Date",
-      description: "Set current date for timeline view",
+      description: "Use any valid Date() string to set the current date for the schedule view. For example: 'Fri May 19 2023 14:00:00 GMT-0800 (Pacific Standard Time)'",
       args: [
         {
           name: "currentDate",


### PR DESCRIPTION
# Description

* adds a `useCurrentDate` hook that checks if there is a date string in AsyncStorage. If there is no date string saved, default to current date.
* consumes `useCurrentDate` in `ScheduleScreen`
* add Reactotron Custom Command to update currentDate value in AsyncStorage

# Graphics

https://user-images.githubusercontent.com/37849890/219488013-0a6afb1a-aa3f-4838-972a-71e22d0101b7.mov


# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
