### PR TITLE
fix: scroll to current button and logic to show past event style

### DIFF
--- a/app/components/ScrollToButton.tsx
+++ b/app/components/ScrollToButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useCallback, useRef } from "react"
 import { ViewStyle, ViewToken, TextStyle, View } from "react-native"
 import { Button, ButtonProps } from "./Button"
 import { Icon } from "./Icon"
@@ -9,6 +9,7 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from "react-native-reanimated"
+import { useFocusEffect } from "@react-navigation/native"
 
 export interface ScrollToButtonProps extends ButtonProps, ReturnType<typeof useScrollToEvent> {
   navigateToCurrentEvent: () => void
@@ -20,9 +21,20 @@ export function useScrollToEvent(scheduleIndex) {
   const currentEventIndex = useSharedValue(-1)
   const currentlyViewingEvents = useSharedValue<number[]>([])
   const currentlyViewingSchedule = useSharedValue(0)
+  const isFocused = useSharedValue(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      isFocused.value = true
+      return () => {
+        isFocused.value = false
+      }
+    }, []),
+  )
 
   const handleViewableEventIndexChanged = useRef(
     ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (!isFocused.value) return
       currentlyViewingEvents.value = viewableItems.map((item) => item.index)
     },
   ).current

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -159,29 +159,34 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
     ({ index, item: schedule }: { index: number; item: Schedule }) => (
       <View style={[$container, { width }]}>
         <FlashList<ScheduleCardProps>
-          ref={scheduleListRefs[schedule.date]}
           data={schedule.events}
-          renderItem={({ item, index }) => (
-            <View style={$cardContainer}>
-              <ScheduleCard {...item} isPast={index < eventIndex} />
-            </View>
-          )}
+          estimatedItemSize={242}
+          estimatedListSize={{ height: schedules.length * 242, width }}
           // To achieve better performance, specify the type based on the item
           getItemType={(item) => item.variant}
-          estimatedItemSize={225}
+          keyExtractor={(item) => item.id}
+          onViewableItemsChanged={handleViewableEventIndexChanged}
+          ref={scheduleListRefs[schedule.date]}
+          scrollEventThrottle={16}
           showsVerticalScrollIndicator={false}
+          viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
           contentContainerStyle={
             scheduleIndex === index && eventIndex !== 0 ? $list : $listWithoutButton
           }
-          scrollEventThrottle={16}
-          onViewableItemsChanged={handleViewableEventIndexChanged}
-          viewabilityConfig={{
-            itemVisiblePercentThreshold: 50,
-          }}
+          renderItem={({ item, index: itemIndex }) => (
+            <View style={$cardContainer}>
+              <ScheduleCard
+                {...item}
+                isPast={
+                  index < scheduleIndex || (index === scheduleIndex && itemIndex < eventIndex)
+                }
+              />
+            </View>
+          )}
         />
       </View>
     ),
-    [scheduleIndex, eventIndex],
+    [scheduleIndex, eventIndex, isFocused],
   )
 
   if (!selectedSchedule) return null

--- a/app/screens/TalkDetailsScreen/SpeakerPanelScreen.tsx
+++ b/app/screens/TalkDetailsScreen/SpeakerPanelScreen.tsx
@@ -2,13 +2,14 @@ import React, { FC } from "react"
 import { ViewStyle, View, TextStyle } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { AppStackParamList } from "../../navigators"
-import { Text, MIN_HEADER_HEIGHT, Screen, Carousel, DynamicCarouselItem } from "../../components"
+import { Text, MIN_HEADER_HEIGHT, Screen, Carousel } from "../../components"
 import { colors, spacing } from "../../theme"
 import { TalkDetailsHeader } from "./TalkDetailsHeader"
 import Animated, { useAnimatedScrollHandler, useSharedValue } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useScheduledEvents } from "../../services/api"
 import { formatDate } from "../../utils/formatDate"
+import { DynamicCarouselItem } from "../../components/carousel/carousel.types"
 
 export const SpeakerPanelScreen: FC<StackScreenProps<AppStackParamList, "SpeakerPanel">> = ({
   route: { params },

--- a/app/services/reactotron/reactotron.ts
+++ b/app/services/reactotron/reactotron.ts
@@ -109,7 +109,8 @@ export function setupReactotron(customConfig: ReactotronConfig = {}) {
         }
       },
       title: "Set Current Date",
-      description: "Use any valid Date() string to set the current date for the schedule view. For example: 'Fri May 19 2023 14:00:00 GMT-0800 (Pacific Standard Time)'",
+      description:
+        "Use any valid Date() string to set the current date for the schedule view. For example: 'Fri May 19 2023 14:00:00 GMT-0800 (Pacific Standard Time)'",
       args: [
         {
           name: "currentDate",


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

Trello Card: 114-bug-scroll-to-current-button-shows-up-when-navigating-to-a-different-screen-and-coming-back

Summary of the changes:

- Fixed the logic to show past event style only on the right date 
- Fixed the `scrollToCurrent` button that shows up when navigating to a different screen and coming back but ONLY on the first render. (iOS only)


# Graphics

#### Style fixed

|Before         | After          |
| -------------- | ------------------ |
| <video width="350" src="https://user-images.githubusercontent.com/53795920/221019908-27a29eba-2b64-491a-a778-ba75dca0ec2d.mp4">|<video width="350" src="https://user-images.githubusercontent.com/53795920/221020291-82da19b3-7138-4644-993b-286968293fcd.mp4">|

#### Button fixed

|Before|After|
|-|-|
|<video width="350" src="https://user-images.githubusercontent.com/53795920/221021397-3807c1f8-122e-49c1-acc5-988d8c8bb256.mp4">|<video width="350" src="https://user-images.githubusercontent.com/53795920/221021796-57b20fff-ed6a-4224-ad06-0b76b97f2c63.mp4">|





# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
