### PR TITLE
fix: no past sponsors

### DIFF
--- a/app/screens/VenueScreen/VenueScreen.tsx
+++ b/app/screens/VenueScreen/VenueScreen.tsx
@@ -48,7 +48,7 @@ const useVenueSections = (): { isLoading: boolean; sections: SectionListData<any
   const tiers = Object.keys(rawTiers).reduce<Record<Tiers, RawSponsor[]>>(
     (acc, tier) => ({
       ...acc,
-      [WEBFLOW_MAP.sponsorTier[tier]]: rawTiers[tier] ?? [],
+      [tier]: rawTiers[tier] ?? [],
     }),
     initialTiers,
   )

--- a/app/services/api/webflow-api.ts
+++ b/app/services/api/webflow-api.ts
@@ -26,6 +26,7 @@ import {
 import {
   cleanedSchedule,
   cleanedSpeakers,
+  cleanedSponsors,
   cleanedTalks,
   cleanedWorkshops,
   convertScheduleToScheduleCard,
@@ -59,10 +60,15 @@ export const useSpeakerNames = () => {
   return useWebflowAPI<RawSpeakerName>(SPEAKER_NAMES.key, SPEAKER_NAMES.collectionId)
 }
 
-export const useSponsors = () => {
-  return useWebflowAPI<RawSponsor>(SPONSORS.key, SPONSORS.collectionId)
-}
+export const useSponsors = (): { isLoading: boolean; data: RawSponsor[] } => {
+  const { data: sponsors, isLoading } = useWebflowAPI<RawSponsor>(
+    SPONSORS.key,
+    SPONSORS.collectionId,
+  )
+  const data = cleanedSponsors(sponsors)
 
+  return { isLoading, data }
+}
 export const useTalks = () => {
   return useWebflowAPI<RawTalk>(TALKS.key, TALKS.collectionId)
 }

--- a/app/services/api/webflow-api.types.ts
+++ b/app/services/api/webflow-api.types.ts
@@ -133,7 +133,9 @@ export interface RawSponsor extends Item {
   logo: ImageRef
 }
 
-export interface Sponsor extends RawSponsor {}
+export type Sponsor = RawSponsor & {
+  "sponsor-tier"?: "Platinum" | "Gold" | "Silver" | "Bronze" | "Other"
+}
 
 export interface RawRecommendations extends Item {
   "city-state-zip"?: string

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -3,68 +3,17 @@ import { formatDate, sortByTime } from "../../utils/formatDate"
 import type {
   RawScheduledEvent,
   RawSpeaker,
+  RawSponsor,
   RawTalk,
   RawWorkshop,
   RecurringEvents,
   ScheduledEvent,
   Speaker,
+  Sponsor,
   Talk,
   Workshop,
 } from "./webflow-api.types"
 import { WEBFLOW_MAP } from "./webflow-consts"
-
-/*
- * Converting workshop data from "type ids" to "type names"
- */
-export const cleanedWorkshops = (
-  workshopsData?: RawWorkshop[],
-  speakersData?: Speaker[],
-): Workshop[] => {
-  return workshopsData
-    ?.filter((workshop) => !workshop._archived && !workshop._draft)
-    .map((workshop) => ({
-      ...workshop,
-      level: WEBFLOW_MAP.workshopLevel[workshop.level],
-      "instructor-info": speakersData?.find(
-        (speaker) => speaker._id === workshop["instructor-info"],
-      ),
-      assistants: workshop?.assistants?.map((id) =>
-        speakersData?.find((speaker) => speaker._id === id),
-      ),
-    }))
-}
-
-/*
- * Converting speakers data from "type ids" to "type names"
- */
-export const cleanedSpeakers = (speakersData?: RawSpeaker[]): Speaker[] => {
-  return speakersData?.map(cleanedSpeaker)
-}
-
-export const cleanedSpeaker = (speaker?: RawSpeaker): Speaker | null => {
-  if (!speaker) return null
-  return {
-    ...speaker,
-    "speaker-type": WEBFLOW_MAP.speakersType[speaker["speaker-type"]],
-    "talk-level": WEBFLOW_MAP.speakersTalk[speaker["talk-level"]],
-  }
-}
-
-export const cleanedTalks = ({
-  speakers,
-  talks,
-}: {
-  speakers?: RawSpeaker[]
-  talks?: RawTalk[]
-}): Talk[] => {
-  return talks?.map((talk) => ({
-    ...talk,
-    "talk-type": WEBFLOW_MAP.talkType[talk["talk-type"]],
-    "speaker-s": talk["speaker-s"].map((speakerId) =>
-      cleanedSpeaker(speakers?.find(({ _id }) => _id === speakerId)),
-    ),
-  }))
-}
 
 /*
  * Converting schedule data from "type ids" to "type names"
@@ -93,6 +42,71 @@ export const cleanedSchedule = ({
       talk: talks?.find((talk) => talk._id === schedule["talk-2"]),
       type: WEBFLOW_MAP.scheduleType[schedule["event-type"]],
       workshop: workshops?.find(({ _id }) => _id === schedule.workshop),
+    }))
+}
+
+/*
+ * Converting speakers data from "type ids" to "type names"
+ */
+export const cleanedSpeakers = (speakersData?: RawSpeaker[]): Speaker[] => {
+  return speakersData?.map(cleanedSpeaker)
+}
+
+export const cleanedSpeaker = (speaker?: RawSpeaker): Speaker | null => {
+  if (!speaker) return null
+  return {
+    ...speaker,
+    "speaker-type": WEBFLOW_MAP.speakersType[speaker["speaker-type"]],
+    "talk-level": WEBFLOW_MAP.speakersTalk[speaker["talk-level"]],
+  }
+}
+
+export const cleanedSponsors = (sponsorsData?: RawSponsor[]): Sponsor[] => {
+  return sponsorsData?.filter((s) => s["is-a-current-sponsor"]).map(cleanedSponsor)
+}
+
+export const cleanedSponsor = (sponsor?: RawSponsor): Sponsor | null => {
+  if (!sponsor) return null
+  return {
+    ...sponsor,
+    "sponsor-tier": WEBFLOW_MAP.sponsorTier[sponsor["sponsor-tier"]],
+  }
+}
+
+export const cleanedTalks = ({
+  speakers,
+  talks,
+}: {
+  speakers?: RawSpeaker[]
+  talks?: RawTalk[]
+}): Talk[] => {
+  return talks?.map((talk) => ({
+    ...talk,
+    "talk-type": WEBFLOW_MAP.talkType[talk["talk-type"]],
+    "speaker-s": talk["speaker-s"].map((speakerId) =>
+      cleanedSpeaker(speakers?.find(({ _id }) => _id === speakerId)),
+    ),
+  }))
+}
+
+/*
+ * Converting workshop data from "type ids" to "type names"
+ */
+export const cleanedWorkshops = (
+  workshopsData?: RawWorkshop[],
+  speakersData?: Speaker[],
+): Workshop[] => {
+  return workshopsData
+    ?.filter((workshop) => !workshop._archived && !workshop._draft)
+    .map((workshop) => ({
+      ...workshop,
+      level: WEBFLOW_MAP.workshopLevel[workshop.level],
+      "instructor-info": speakersData?.find(
+        (speaker) => speaker._id === workshop["instructor-info"],
+      ),
+      assistants: workshop?.assistants?.map((id) =>
+        speakersData?.find((speaker) => speaker._id === id),
+      ),
     }))
 }
 

--- a/app/services/reactotron/reactotron.ts
+++ b/app/services/reactotron/reactotron.ts
@@ -109,7 +109,8 @@ export function setupReactotron(customConfig: ReactotronConfig = {}) {
         }
       },
       title: "Set Current Date",
-      description: "Use any valid Date() string to set the current date for the schedule view. For example: 'Fri May 19 2023 14:00:00 GMT-0800 (Pacific Standard Time)'",
+      description:
+        "Use any valid Date() string to set the current date for the schedule view. For example: 'Fri May 19 2023 14:00:00 GMT-0800 (Pacific Standard Time)'",
       args: [
         {
           name: "currentDate",


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

Trello Card: 112-bug-dont-include-past-sponsors

Summary of the changes:

- Added a helper `cleanedSponsors` to omit past sponsors before returning from the `useSponsors` hook

# Graphics

| Before| After 1| After 2|
|-|-|-|
|<img width="372" alt="CleanShot 2023-02-23 at 16 20 08@2x" src="https://user-images.githubusercontent.com/53795920/221235532-6e8382bc-d4ba-46e8-b5c9-239f20e58e90.png">| <img width="389" alt="CleanShot 2023-02-24 at 09 32 21@2x" src="https://user-images.githubusercontent.com/53795920/221235699-f3bc98e9-c69f-4fe7-bb22-73777007ff43.png">|<img width="385" alt="CleanShot 2023-02-24 at 09 32 40@2x" src="https://user-images.githubusercontent.com/53795920/221235754-38fe3538-9402-449c-99e4-3c9363d6b2a5.png">|

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
