### PR TITLE
fix: font scaling

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -232,7 +232,13 @@ export function HeaderAction(props: HeaderActionProps) {
         disabled={!onPress}
         activeOpacity={0.8}
       >
-        <Text weight="medium" size="md" text={content} style={$actionText} />
+        <Text
+          maxFontSizeMultiplier={1.5}
+          weight="medium"
+          size="md"
+          text={content}
+          style={$actionText}
+        />
       </TouchableOpacity>
     )
   }

--- a/app/components/carousel/CarouselCard.tsx
+++ b/app/components/carousel/CarouselCard.tsx
@@ -179,6 +179,8 @@ const $leftButton: ViewStyle = {
 }
 
 const $ctaContainer: ViewStyle = {
+  flex: 1,
+  flexWrap: "wrap",
   flexDirection: "row",
   marginTop: spacing.medium,
 }

--- a/app/screens/DebugScreen.tsx
+++ b/app/screens/DebugScreen.tsx
@@ -43,7 +43,12 @@ export const DebugScreen: FC<StackScreenProps<AppStackParamList, "Debug">> = () 
   }, [])
 
   return (
-    <Screen style={$root} safeAreaEdges={["bottom"]}>
+    <Screen
+      style={$root}
+      preset="scroll"
+      ScrollViewProps={{ showsVerticalScrollIndicator: false }}
+      safeAreaEdges={["bottom"]}
+    >
       <Text preset="bold" tx="debugScreen.pushToken" style={$subtitle} />
       <Text text={fcmToken} selectable />
       <Button

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -72,11 +72,14 @@ const ExploreMap = ({ item }: { item: ExploreMapProps }) => {
       <Text text={translate("exploreScreen.exploreNeighborhoods")} preset="screenHeading" />
       <Text text={item.description} style={$description} />
       <View style={$creditContainer}>
-        <Text text={item.credit.text} />
-        <Text onPress={() => openLinkInBrowser(item.credit.link)} style={$credit}>
-          {" "}
-          {item.credit.author}
-        </Text>
+        <Text maxFontSizeMultiplier={1.5} text={item.credit.text} />
+        <Text
+          maxFontSizeMultiplier={1.5}
+          onPress={() => openLinkInBrowser(item.credit.link)}
+          style={$credit}
+          // Leave the space before the author name so it has the spacing from the text before it
+          text={` ${item.credit.author}`}
+        />
       </View>
     </View>
   )

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -72,9 +72,8 @@ const ExploreMap = ({ item }: { item: ExploreMapProps }) => {
       <Text text={translate("exploreScreen.exploreNeighborhoods")} preset="screenHeading" />
       <Text text={item.description} style={$description} />
       <View style={$creditContainer}>
-        <Text maxFontSizeMultiplier={1.5} text={item.credit.text} />
+        <Text text={item.credit.text} />
         <Text
-          maxFontSizeMultiplier={1.5}
           onPress={() => openLinkInBrowser(item.credit.link)}
           style={$credit}
           // Leave the space before the author name so it has the spacing from the text before it
@@ -269,6 +268,8 @@ const $description: TextStyle = {
 }
 
 const $creditContainer: ViewStyle = {
+  flex: 1,
+  flexWrap: "wrap",
   flexDirection: "row",
 }
 

--- a/app/screens/TalkDetailsScreen/TalkDetailsHeader.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsHeader.tsx
@@ -38,7 +38,11 @@ export const TalkDetailsHeader: React.FunctionComponent<TalkDetailsHeaderProps> 
     return (
       <View style={$rowContainer}>
         <BackButton />
-        <AnimatedText preset="navHeader" style={[$centerTitle, $animatedTitle]}>
+        <AnimatedText
+          allowFontScaling={false}
+          preset="navHeader"
+          style={[$centerTitle, $animatedTitle]}
+        >
           {title}
         </AnimatedText>
       </View>


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

Trello Card: 
- 120-a11y-font-scaling-info-header-is-unreadable
- 121-a11y-font-scaling-debug-screen-needs-to-be-scrollable
- 122-a11y-font-scaling-long-talk-titles-overlap-text-on-talk-details-after-scrolling-down
- 123-a11y-font-scaling-map-illustration-link-cut-off

Summary of the changes 

 - Font scaling issues that are mentioned in those Trello cards
 - `Website` + `View on Map` link buttons on the `Food and Drink` carousel in Explore Screen


# Graphics

|120|121|122|123|
|-|-|-|-|
|<img width="200" src="https://user-images.githubusercontent.com/53795920/223545608-678a93c1-a3ba-43af-be0a-bdc6794b3b23.png">|<img width="200" src="https://user-images.githubusercontent.com/53795920/223545668-012bfd50-7607-4eec-94a3-7a4b0a131697.gif">|<img width="200" src="https://user-images.githubusercontent.com/53795920/223545802-189615d7-fc5a-4a5d-81dc-c2e7a0e7a75a.png">|<img width="200" src="https://user-images.githubusercontent.com/53795920/223545916-d0cf7476-0bed-430e-90c4-7b70a86c30ad.png">|

|`Website` + `View on Map` buttons|fix|
|-|-|
|<img width="250" alt="CleanShot 2023-03-07 at 13 17 50@2x" src="https://user-images.githubusercontent.com/53795920/223546703-a49102a3-deca-4afc-975d-a516124ae864.png">|<img width="250" src="https://user-images.githubusercontent.com/53795920/223546751-a9dc7288-933c-48d4-a1b9-f5d944b0c1ec.png">|



# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
