### PR TITLE
specify initial route name for app navigator

### DIFF
--- a/app/navigators/AppNavigator.tsx
+++ b/app/navigators/AppNavigator.tsx
@@ -65,7 +65,7 @@ const Stack = createNativeStackNavigator<AppStackParamList>()
 
 const AppStack = () => {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName={"Welcome"}>
       <Stack.Screen name="Debug" component={DebugScreen} />
       <Stack.Screen
         name="PartyDetails"


### PR DESCRIPTION
# Description

- Set an initial route on the navigator since the screens are in alphabetical order now

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
