### PR TITLE
Fix/multi scroll width

### DIFF
--- a/app/components/carousel/CarouselCard.tsx
+++ b/app/components/carousel/CarouselCard.tsx
@@ -43,10 +43,12 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
   rightButton,
   scrollX,
   socialButtons,
+  totalCardCount,
   variant,
 }) => {
   const { label, subtitle, meta, body, image } = item as DynamicCarouselItem
   const source = subtitle ? image : item
+  const isMultipleSpeakers = variant === "speaker" && totalCardCount > 1 && index === totalCardCount
 
   const inputRange = [
     (index - 2) * CAROUSEL_IMAGE_WIDTH,
@@ -62,7 +64,7 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
   const $animatedSlideData = useAnimatedStyle(() => {
     const translateX = interpolate(scrollX.value, inputRange, [
       CAROUSEL_IMAGE_WIDTH,
-      spacing.medium,
+      isMultipleSpeakers ? -spacing.extraSmall : spacing.medium,
       -CAROUSEL_IMAGE_WIDTH,
     ])
 
@@ -80,7 +82,7 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
           <BoxShadow preset="primary" offset={5}>
             <Animated.Image
               source={source}
-              style={[$image, imageStyle, { width: Number($carouselCard.width) - 36 }]}
+              style={[$image, imageStyle, { width: CAROUSEL_IMAGE_WIDTH - 36 }]}
             />
           </BoxShadow>
         </Animated.View>

--- a/app/components/carousel/constants.ts
+++ b/app/components/carousel/constants.ts
@@ -2,6 +2,6 @@ import { Dimensions } from "react-native"
 import { spacing } from "../../theme"
 
 const { width: SCREEN_WIDTH } = Dimensions.get("screen")
-export const CAROUSEL_IMAGE_WIDTH = SCREEN_WIDTH * 0.9
+export const CAROUSEL_IMAGE_WIDTH = SCREEN_WIDTH * 0.85
 export const SPACING = spacing.extraSmall
-export const SPACER_WIDTH = (SCREEN_WIDTH - CAROUSEL_IMAGE_WIDTH) / 2
+export const SPACER_WIDTH = (SCREEN_WIDTH - SCREEN_WIDTH * 0.9) / 2


### PR DESCRIPTION
# Description

[Trello Card](134-multi-scroll-width-issue-multi-speakers) — #87 

- updated our Carousel width constant
- cleaned up some UI math to make sure our last card spacing is correct

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <img width="300" src="https://user-images.githubusercontent.com/9324607/230171782-45e9f3ef-1f8b-4a6f-91b7-137c93007137.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/230171889-0b74436e-656e-41d6-a61e-303afb906ccd.png" /> | <img width="300" src="https://user-images.githubusercontent.com/9324607/230171513-56f6f1f3-be65-4536-9826-7b485193b82e.png" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [x] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
