### PR TITLE
(fix) tackling multiple bugs

### DIFF
--- a/app/components/carousel/CarouselCard.tsx
+++ b/app/components/carousel/CarouselCard.tsx
@@ -48,7 +48,7 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
 }) => {
   const { label, subtitle, meta, body, image } = item as DynamicCarouselItem
   const source = subtitle ? image : item
-  const isMultipleSpeakers = variant === "speaker" && totalCardCount > 1 && index === totalCardCount
+  const isMultipleCards = totalCardCount > 1 && index === totalCardCount
 
   const inputRange = [
     (index - 2) * CAROUSEL_IMAGE_WIDTH,
@@ -64,7 +64,7 @@ export const CarouselCard: React.FunctionComponent<CarouselCardProps> & SubCompo
   const $animatedSlideData = useAnimatedStyle(() => {
     const translateX = interpolate(scrollX.value, inputRange, [
       CAROUSEL_IMAGE_WIDTH,
-      isMultipleSpeakers ? -spacing.extraSmall : spacing.medium,
+      isMultipleCards ? -spacing.extraSmall : spacing.medium,
       -CAROUSEL_IMAGE_WIDTH,
     ])
 

--- a/app/screens/InfoScreen.tsx
+++ b/app/screens/InfoScreen.tsx
@@ -102,5 +102,6 @@ const $codeOfConductHeading: TextStyle = {
 
 const $screenHeading: ViewStyle = {
   marginTop: spacing.extraLarge,
+  marginBottom: spacing.medium,
   paddingHorizontal: spacing.large,
 }

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -26,7 +26,7 @@ const Header = ({ formattedEndTime, formattedStartTime, title, isPast }: HeaderP
       {formattedStartTime}
       {!!formattedEndTime && ` - ${formattedEndTime}`}
     </Text>
-    <Text preset="eventTitle" style={isPast ? $pastTitleText : $titleText}>
+    <Text preset="eventTitle" style={[isPast ? $pastTitleText : $titleText, $titleTextBase]}>
       {title}
     </Text>
   </View>
@@ -281,6 +281,10 @@ const $talkRecordingLabel: TextStyle = {
 const $timeText: TextStyle = {
   color: colors.palette.neutral800,
   marginBottom: spacing.large,
+}
+
+const $titleTextBase: TextStyle = {
+  width: "80%",
 }
 
 const $pastTimeText: TextStyle = {

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -26,7 +26,7 @@ const Header = ({ formattedEndTime, formattedStartTime, title, isPast }: HeaderP
       {formattedStartTime}
       {!!formattedEndTime && ` - ${formattedEndTime}`}
     </Text>
-    <Text preset="eventTitle" style={[isPast ? $pastTitleText : $titleText, $titleTextBase]}>
+    <Text preset="eventTitle" style={[$titleTextBase, isPast ? $pastTitleText : $titleText]}>
       {title}
     </Text>
   </View>


### PR DESCRIPTION
# Description

[Trello Card](139-the-last-item-in-carousel-has-additional-padding) — #96 
[Trello Card](137-title-of-schedule-card-is-overflowing-into-avatar-image) — #98 
[Trello Card](138-need-margins-between-title-and-carousel) — #97 

tackling 3 bugs in the PR:
1. title of schedule card is overflowing into avatar image #98
2. Need margins between title and carousel #97 
3. The last item in carousel has additional padding #96

# Graphics

| #97            | #98            | #96            |
| -------------- | ------------------ | ------------------ |
| <img width="250" src="https://user-images.githubusercontent.com/9324607/230459066-b0a88187-fd10-4c9b-bebc-3613cf1fa68a.png" /> | <img width="250" src="https://user-images.githubusercontent.com/9324607/230458945-036dcc4c-0c76-4fde-9dde-bbe865799b02.png" /> | <img width="250" src="https://user-images.githubusercontent.com/9324607/230458897-c752e81e-86da-4154-b7cb-2f835a0c8b15.png" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [x] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
