### PR TITLE
Explore Screen Updates

### DIFF
--- a/app/components/carousel/Carousel.tsx
+++ b/app/components/carousel/Carousel.tsx
@@ -10,6 +10,7 @@ import { openMap } from "../../utils/openMap"
 import { SocialButton } from "../SocialButton"
 import { CAROUSEL_IMAGE_WIDTH, SPACER_WIDTH } from "./constants"
 import { CarouselProps, DynamicCarouselItem, Spacer } from "./carousel.types"
+import { ButtonLink } from "../ButtonLink"
 
 // ! https://github.com/software-mansion/react-native-reanimated/issues/457
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList)
@@ -125,6 +126,11 @@ export function Carousel(props: CarouselProps) {
             style={[!props.meta ? $mt : undefined, $mb]}
           />
           <Text text={props.body} style={$body} />
+          {props.link && (
+            <ButtonLink openLink={() => openLink(props.link.link)} style={$buttonLink}>
+              {props.link.text}
+            </ButtonLink>
+          )}
           {props.button && (
             <Button text={props.button.text} onPress={() => openLink(props.button.link)} />
           )}
@@ -155,6 +161,10 @@ const $meta: ViewStyle = {
 }
 
 const $body: TextStyle = {
+  marginBottom: spacing.large,
+}
+
+const $buttonLink: ViewStyle = {
   marginBottom: spacing.large,
 }
 

--- a/app/components/carousel/carousel.types.ts
+++ b/app/components/carousel/carousel.types.ts
@@ -5,6 +5,7 @@ import { IconProps } from "../Icon"
 export interface StaticCarouselProps {
   body: string
   button?: ButtonData & ButtonProps
+  link?: { link: string; text: string }
   data: ImageSourcePropType[]
   meta?: string
   preset: "static"

--- a/app/components/carousel/carousel.types.ts
+++ b/app/components/carousel/carousel.types.ts
@@ -2,7 +2,7 @@ import { ImageSourcePropType, ImageStyle } from "react-native"
 import { ButtonProps } from "../Button"
 import { IconProps } from "../Icon"
 
-interface StaticCarouselProps {
+export interface StaticCarouselProps {
   body: string
   button?: ButtonData & ButtonProps
   data: ImageSourcePropType[]

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -33,8 +33,10 @@ const en = {
   exploreScreen: {
     title: "Explore",
     nearbyFoodAndDrink: "Nearby food and drink",
-    downtownArtMurals: "Downtown art murals",
-    exploreNeighborhoods: "Explore neighborhoods",
+    sightSee: "Things to see",
+    uniqueToPortland: "Unique to Portland",
+    openInMaps: "Open in maps",
+    website: "Website",
   },
   tabNavigator: {
     scheduleTab: "Schedule",

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -1,16 +1,13 @@
 import React, { FC } from "react"
 import {
   ActivityIndicator,
-  Image,
-  ImageSourcePropType,
-  ImageStyle,
   SectionList,
   SectionListData,
   TextStyle,
   View,
   ViewStyle,
 } from "react-native"
-import { Button, Carousel, Screen, Text } from "../../components"
+import { Carousel, Screen, Text } from "../../components"
 import { TabScreenProps } from "../../navigators/TabNavigator"
 import { colors, spacing } from "../../theme"
 import { useHeader } from "../../hooks/useHeader"
@@ -19,20 +16,7 @@ import { useRecommendations } from "../../services/api"
 import { WEBFLOW_MAP } from "../../services/api/webflow-consts"
 import { groupBy } from "../../services/api/webflow-helpers"
 import { RawRecommendations } from "../../services/api/webflow-api.types"
-import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
-
-const exploreMap = require("../../../assets/images/exploreMap.png")
-
-interface CreditData {
-  author: string
-  text: string
-  link: string
-}
-interface ExploreMapProps {
-  image: ImageSourcePropType
-  description: string
-  credit: CreditData
-}
+import { StaticCarouselProps } from "../../components/carousel/carousel.types"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
 type RecommendationType = typeof recommendationTypes[number]
@@ -43,79 +27,29 @@ const initialRecs = recommendationTypes.reduce<GroupedRecommendations>(
   {} as GroupedRecommendations,
 )
 
-const FoodAndDrink = ({ item }) => {
-  return <Carousel preset="dynamic" data={item} />
-}
-
-const ArtMurals = ({ item }) => {
-  return (
-    <View style={$carousel}>
-      <Carousel preset="dynamic" data={item} />
-      <View style={$artButtonContainer}>
-        <Button
-          text="Open Google Maps list"
-          onPress={() =>
-            openLinkInBrowser(
-              "https://www.google.com/maps/@45.5222313,-122.6833028,17z/data=!3m1!4b1!4m2!11m1!2sZuep6RPMS_uPvVRGkziJ3w",
-            )
-          }
-        />
-      </View>
-    </View>
-  )
-}
-
-const ExploreMap = ({ item }: { item: ExploreMapProps }) => {
-  return (
-    <View style={$exploreMapContainer}>
-      <Image source={item.image} style={$exploreMap} />
-      <Text text={translate("exploreScreen.exploreNeighborhoods")} preset="screenHeading" />
-      <Text text={item.description} style={$description} />
-      <View style={$creditContainer}>
-        <Text text={item.credit.text} />
-        <Text
-          onPress={() => openLinkInBrowser(item.credit.link)}
-          style={$credit}
-          // Leave the space before the author name so it has the spacing from the text before it
-          text={` ${item.credit.author}`}
-        />
-      </View>
-    </View>
-  )
-}
-
-const Neighborhood = ({ item }) => {
-  return (
-    <View style={$carousel}>
-      <Carousel
-        preset="static"
-        data={item.images}
-        subtitle={item.subtitle}
-        body={item.body}
-        meta={item.meta}
-        button={item.button}
-      />
-    </View>
-  )
-}
+const RenderItem = ({ item }: { item: StaticCarouselProps }) => (
+  <View style={$carouselWrapper}>
+    <Carousel {...item} />
+  </View>
+)
 
 const sectionTitle = (type: RecommendationType) => {
   switch (type) {
     case "Food/Drink":
       return translate("exploreScreen.nearbyFoodAndDrink")
     case "SightSee":
-      return translate("exploreScreen.downtownArtMurals")
-    // Don't show this section for now since it's not in the CMS
-    // case "Unique to Portland":
-    //   return "Unique to Portland"
-    case "Neighborhood":
-      return undefined
+      return translate("exploreScreen.sightSee")
+    case "Unique/to/Portland":
+      return translate("exploreScreen.uniqueToPortland")
     default:
       return translate("exploreScreen.nearbyFoodAndDrink")
   }
 }
 
-const useRecommendationSections = (): { isLoading: boolean; sections: SectionListData<any>[] } => {
+const useRecommendationSections = (): {
+  isLoading: boolean
+  sections: Array<SectionListData<StaticCarouselProps>>
+} => {
   const { data: recommendations = [], isLoading } = useRecommendations()
 
   const rawRecs = groupBy("type")(recommendations)
@@ -129,77 +63,33 @@ const useRecommendationSections = (): { isLoading: boolean; sections: SectionLis
 
   return {
     isLoading,
-    sections: [
-      {
-        title: sectionTitle("Food/Drink"),
-        renderItem: FoodAndDrink,
-        data: [
-          recs["Food/Drink"].map((rec) => ({
-            image: { uri: rec.images[0]?.url },
-            subtitle: rec.name,
-            meta: rec.descriptor,
-            body: rec.description,
-            leftButton: rec["external-url"]
-              ? {
-                  text: "Website",
-                  link: rec["external-url"],
-                }
-              : undefined,
-            rightButton:
-              rec["street-address"] && rec["city-state-zip"]
+    sections: Object.entries(recs).map(
+      ([key, value]: [RecommendationType, RawRecommendations[]]) => ({
+        title: sectionTitle(key),
+        renderItem: RenderItem,
+        data: value.map(
+          (item) =>
+            ({
+              data: item.images.map((image) => ({ uri: image.url })),
+              subtitle: item.name,
+              meta: item.descriptor,
+              body: item.description,
+              button: item["external-url"]
                 ? {
-                    text: "View on Map",
-                    link: `${rec["street-address"]},${rec["city-state-zip"]}`,
+                    text: translate("exploreScreen.website"),
+                    link: item["external-url"],
+                  }
+                : item["street-address"] && item["city-state-zip"]
+                ? {
+                    text: translate("exploreScreen.openInMaps"),
+                    link: `${item["street-address"]},${item["city-state-zip"]}`,
                   }
                 : undefined,
-          })),
-        ],
-      },
-      {
-        title: sectionTitle("SightSee"),
-        renderItem: ArtMurals,
-        data: [
-          recs.SightSee.map((rec) => ({
-            image: { uri: rec.images[0]?.url },
-            subtitle: rec.name,
-            meta: `${rec.descriptor} • free`,
-            body: rec.description,
-          })),
-        ],
-      },
-      {
-        title: sectionTitle("Neighborhood"),
-        renderItem: ExploreMap,
-        data: [
-          {
-            image: exploreMap,
-            description:
-              "Here’s a quick guide to the areas around the city. Each area has it’s own distinct feel and different things to do!",
-
-            credit: {
-              text: "map illustration by",
-              author: "Subin Yang",
-              link: "https://www.travelportland.com/about-us/meet-our-writers/#subin-yang",
-            },
-          },
-        ],
-      },
-      {
-        title: sectionTitle("Neighborhood"),
-        renderItem: Neighborhood,
-        data: recs.Neighborhood.map((rec) => ({
-          images: rec.images.map((image) => ({ uri: image.url })),
-          subtitle: rec.name,
-          meta: rec.descriptor,
-          body: rec.description,
-          button: {
-            text: "Open our Yelp guide",
-            // The external link is not ready in the CMS yet
-            link: rec["external-url"],
-          },
-        })),
-      },
-    ],
+              preset: "static",
+            } as StaticCarouselProps),
+        ),
+      }),
+    ),
   }
 }
 
@@ -216,11 +106,13 @@ export const ExploreScreen: FC<TabScreenProps<"Explore">> = () => {
         <SectionList
           stickySectionHeadersEnabled={false}
           sections={sections}
-          renderSectionHeader={({ section: { title } }) => (
-            <Text preset="screenHeading" style={!!title && $heading}>
-              {title}
-            </Text>
-          )}
+          renderSectionHeader={({ section: { title, data } }) =>
+            data.length > 0 ? (
+              <Text preset="screenHeading" style={!!title && $heading}>
+                {title}
+              </Text>
+            ) : null
+          }
         />
       )}
     </Screen>
@@ -239,40 +131,10 @@ const $activityIndicator: ViewStyle = {
 
 const $heading: TextStyle = {
   marginTop: spacing.large,
+  marginBottom: spacing.medium,
   paddingHorizontal: spacing.large,
 }
 
-const $carousel: ViewStyle = {
-  marginBottom: spacing.extraLarge,
-}
-
-const $artButtonContainer: ViewStyle = {
-  flex: 1,
-  paddingHorizontal: spacing.large,
-}
-
-const $exploreMapContainer: ViewStyle = {
-  paddingHorizontal: spacing.large,
-  marginBottom: spacing.extraLarge,
-}
-
-const $exploreMap: ImageStyle = {
-  width: "100%",
+const $carouselWrapper: ViewStyle = {
   marginBottom: spacing.large,
-  borderRadius: 4,
-}
-
-const $description: TextStyle = {
-  marginTop: spacing.extraSmall,
-  marginBottom: spacing.large,
-}
-
-const $creditContainer: ViewStyle = {
-  flex: 1,
-  flexWrap: "wrap",
-  flexDirection: "row",
-}
-
-const $credit: TextStyle = {
-  textDecorationLine: "underline",
 }

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -74,17 +74,6 @@ const useRecommendationSections = (): {
               subtitle: item.name,
               meta: item.descriptor,
               body: item.description,
-              button: item["external-url"]
-                ? {
-                    text: translate("exploreScreen.website"),
-                    link: item["external-url"],
-                  }
-                : item["street-address"] && item["city-state-zip"]
-                ? {
-                    text: translate("exploreScreen.openInMaps"),
-                    link: `${item["street-address"]},${item["city-state-zip"]}`,
-                  }
-                : undefined,
               preset: "static",
             } as StaticCarouselProps),
         ),

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -74,6 +74,19 @@ const useRecommendationSections = (): {
               subtitle: item.name,
               meta: item.descriptor,
               body: item.description,
+              link: item["external-url"]
+                ? {
+                    text: translate("exploreScreen.openInMaps"),
+                    link: item["external-url"],
+                  }
+                : undefined,
+              button:
+                item["street-address"] && item["city-state-zip"]
+                  ? {
+                      text: translate("exploreScreen.openInMaps"),
+                      link: `${item["street-address"]},${item["city-state-zip"]}`,
+                    }
+                  : undefined,
               preset: "static",
             } as StaticCarouselProps),
         ),

--- a/app/services/api/webflow-consts.ts
+++ b/app/services/api/webflow-consts.ts
@@ -115,7 +115,6 @@ export const WEBFLOW_MAP = {
   recommendationType: {
     "3541dc4db3502b41c75043518060800d": "Food/Drink",
     a5028d71ed9c315a6e9fa67778f2579d: "SightSee",
-    // f42e3ac1a464004c28d91ddf3945b654: "Unique to Portland",
-    "0e40a1811b85d1f596d891182dffba1a": "Neighborhood",
+    f42e3ac1a464004c28d91ddf3945b654: "Unique/to/Portland",
   },
 } as const


### PR DESCRIPTION
# Description

[Trello Card](143-need-to-delete-this-info-from-explore) — #101 
[Trello Card](142-not-all-categories-made-it-to-the-app-on-explore) — #102 
[Trello Card](129-open-our-yelp-guide-kills-the-app) — #89 (we've removed the buttons altogether which fixes this) 

Restructuring the `Explore` screen to come from the CMS so @justinhuskey can control it

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <img width="300" src="https://user-images.githubusercontent.com/9324607/231275466-19018094-c499-4f66-85fd-578c2831887c.png" /> | <img width="300" src="https://user-images.githubusercontent.com/9324607/231275529-aa0ffcbf-7697-47cd-aed0-46c6aa7601fb.png" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
