### PR TITLE
Refactor to use `Suspense` instead of `useLoading`

### DIFF
--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -21,7 +21,7 @@ import { groupBy } from "../../utils/groupBy"
 import { customSortObjectKeys } from "../../utils/customSort"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
-type RecommendationType = (typeof recommendationTypes)[number]
+type RecommendationType = typeof recommendationTypes[number]
 type GroupedRecommendations = Record<RecommendationType, RawRecommendations[]>
 
 const initialRecs = recommendationTypes.reduce<GroupedRecommendations>(

--- a/app/screens/InfoScreen/OurSponsorsScreen.tsx
+++ b/app/screens/InfoScreen/OurSponsorsScreen.tsx
@@ -18,7 +18,7 @@ import { SponsorCard } from "./SponsorCard"
 import { groupBy } from "../../utils/groupBy"
 
 const sponsorTiers = Object.values(WEBFLOW_MAP.sponsorTier)
-type Tiers = (typeof sponsorTiers)[number]
+type Tiers = typeof sponsorTiers[number]
 
 const initialTiers = sponsorTiers.reduce<Record<Tiers, RawSponsor[]>>(
   (acc, tier) => ({ ...acc, [tier]: [] }),

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useMemo } from "react"
+import React, { Suspense, useEffect, useLayoutEffect, useMemo } from "react"
 import {
   AccessibilityInfo,
   ActivityIndicator,
@@ -64,13 +64,8 @@ const requestUserPermission = async () => {
   }
 }
 
-export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
-  const {
-    isLoading,
-    isRefetching,
-    schedules,
-    refetch: refetchScheduleScreenData,
-  } = useScheduleScreenData()
+const Layout: React.FC<TabScreenProps<"Schedule">> = () => {
+  const { schedules, refetch: refetchScheduleScreenData } = useScheduleScreenData()
   const [selectedSchedule, setSelectedSchedule] = React.useState<Schedule>(schedules[0])
 
   useHeader({ title: formatDate(selectedSchedule.date, "EE, MMMM dd") }, [selectedSchedule])
@@ -243,7 +238,7 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
             refreshControl={
               <RefreshControl
                 onRefresh={refetchScheduleScreenData}
-                refreshing={isRefetching}
+                refreshing={false}
                 tintColor={colors.palette.neutral100}
               />
             }
@@ -258,32 +253,35 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
 
   return (
     <>
-      <View style={$root}>
-        {isLoading && (
-          <ActivityIndicator color={colors.tint} size="large" style={$activityIndicator} />
-        )}
-        {!isLoading && schedules && (
-          <Animated.FlatList
-            ref={hScrollRef}
-            data={schedules}
-            keyExtractor={(item) => item.date}
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            pagingEnabled
-            onScroll={scrollHandler}
-            onViewableItemsChanged={handleViewableScheduleIndexChanged}
-            bounces={false}
-            scrollEventThrottle={16}
-            decelerationRate="fast"
-            renderItem={renderSchedule}
-          />
-        )}
-      </View>
+      <Animated.FlatList
+        ref={hScrollRef}
+        data={schedules}
+        keyExtractor={(item) => item.date}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        pagingEnabled
+        onScroll={scrollHandler}
+        onViewableItemsChanged={handleViewableScheduleIndexChanged}
+        bounces={false}
+        scrollEventThrottle={16}
+        decelerationRate="fast"
+        renderItem={renderSchedule}
+      />
       <ScheduleDayPicker {...{ scrollX, onItemPress, schedules, selectedSchedule }} />
       <ScrollToButton navigateToCurrentEvent={navigateToCurrentEvent} {...scrollToButtonProps} />
     </>
   )
 }
+
+export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = (props) => (
+  <View style={$root}>
+    <Suspense
+      fallback={<ActivityIndicator color={colors.tint} size="large" style={$activityIndicator} />}
+    >
+      <Layout {...props} />
+    </Suspense>
+  </View>
+)
 
 const $root: ViewStyle = {
   flex: 1,

--- a/app/screens/VenuesScreen/VenuesScreen.tsx
+++ b/app/screens/VenuesScreen/VenuesScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react"
+import React, { FC, Suspense } from "react"
 import {
   ActivityIndicator,
   ImageSourcePropType,
@@ -38,10 +38,9 @@ const getVenueDate = (venueTag: string): string => {
 }
 
 const useVenuesSections = (): {
-  isLoading: boolean
   sections: Array<SectionListData<Array<VenuesSection>>>
 } => {
-  const { data: venues = [], isLoading: venuesLoading } = useVenues()
+  const { data: venues = [] } = useVenues()
   const sortedVenues = customSort(venues, "slug", [
     "the-armory",
     "after-party-expensify-office",
@@ -49,7 +48,6 @@ const useVenuesSections = (): {
   ])
 
   return {
-    isLoading: venuesLoading,
     sections: [
       {
         data: [
@@ -81,30 +79,35 @@ const VenueCard = ({ body, cta, imageSource, subtitle, title }: VenuesSection) =
   />
 )
 
+const Layout = () => {
+  const { sections } = useVenuesSections()
+
+  return (
+    <SectionList
+      showsVerticalScrollIndicator={false}
+      stickySectionHeadersEnabled={false}
+      sections={sections}
+      renderItem={({ item }) => (
+        <>
+          {item.map((venue, index) => (
+            <VenueCard key={index} {...venue} />
+          ))}
+        </>
+      )}
+    />
+  )
+}
+
 export const VenuesScreen: FC<TabScreenProps<"Venues">> = () => {
   useHeader({ title: translate("venuesScreen.title") })
 
-  const { sections, isLoading } = useVenuesSections()
-
   return (
     <Screen style={$root} preset="fixed">
-      {isLoading && (
-        <ActivityIndicator color={colors.tint} size="large" style={$activityIndicator} />
-      )}
-      {!isLoading && sections.length > 0 && (
-        <SectionList
-          showsVerticalScrollIndicator={false}
-          stickySectionHeadersEnabled={false}
-          sections={sections}
-          renderItem={({ item }) => (
-            <>
-              {item.map((venue, index) => (
-                <VenueCard key={index} {...venue} />
-              ))}
-            </>
-          )}
-        />
-      )}
+      <Suspense
+        fallback={<ActivityIndicator color={colors.tint} size="large" style={$activityIndicator} />}
+      >
+        <Layout />
+      </Suspense>
     </Screen>
   )
 }

--- a/app/services/api/react-query.ts
+++ b/app/services/api/react-query.ts
@@ -1,4 +1,11 @@
 import { QueryClient } from "@tanstack/react-query"
 
 // Creating a react-query client with the stale time set to "Infinity" so that its never stale
-export const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } })
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      staleTime: Infinity,
+    },
+  },
+})

--- a/app/services/api/webflow-api.ts
+++ b/app/services/api/webflow-api.ts
@@ -60,14 +60,11 @@ export const useSpeakerNames = () => {
   return useWebflowAPI<RawSpeakerName>(SPEAKER_NAMES.key, SPEAKER_NAMES.collectionId)
 }
 
-export const useSponsors = (): { isLoading: boolean; data: RawSponsor[] } => {
-  const { data: sponsors, isLoading } = useWebflowAPI<RawSponsor>(
-    SPONSORS.key,
-    SPONSORS.collectionId,
-  )
+export const useSponsors = (): { data: RawSponsor[] } => {
+  const { data: sponsors } = useWebflowAPI<RawSponsor>(SPONSORS.key, SPONSORS.collectionId)
   const data = cleanedSponsors(sponsors)
 
-  return { isLoading, data }
+  return { data }
 }
 export const useTalks = () => {
   return useWebflowAPI<RawTalk>(TALKS.key, TALKS.collectionId)


### PR DESCRIPTION
# Description

As an experiment, this PR refactors TanStack query to utilize `Suspense` to handle loading states instead of `isLoading` conditional.
https://tanstack.com/query/v4/docs/react/guides/suspense

This will require some further investigation to figure out whether or not this is a useful pattern, has performance benefits, etc.

# Graphics

| Device | Before | After |
|--------|--------|--------|
| iOS | <video src="https://user-images.githubusercontent.com/37849890/231332084-bd1325e2-9944-4611-889b-aaeac3e92c78.mov"/> | <video src="https://user-images.githubusercontent.com/37849890/231332381-6a88b352-6711-4436-9180-5f60918c4f33.mov" /> |
| Android | n/a | n/a | 

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
