### PR TITLE
Prefetch event schedule data to improve initial load speed

### DIFF
--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -21,7 +21,7 @@ import { groupBy } from "../../utils/groupBy"
 import { customSortObjectKeys } from "../../utils/customSort"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
-type RecommendationType = typeof recommendationTypes[number]
+type RecommendationType = (typeof recommendationTypes)[number]
 type GroupedRecommendations = Record<RecommendationType, RawRecommendations[]>
 
 const initialRecs = recommendationTypes.reduce<GroupedRecommendations>(

--- a/app/screens/InfoScreen/OurSponsorsScreen.tsx
+++ b/app/screens/InfoScreen/OurSponsorsScreen.tsx
@@ -18,7 +18,7 @@ import { SponsorCard } from "./SponsorCard"
 import { groupBy } from "../../utils/groupBy"
 
 const sponsorTiers = Object.values(WEBFLOW_MAP.sponsorTier)
-type Tiers = typeof sponsorTiers[number]
+type Tiers = (typeof sponsorTiers)[number]
 
 const initialTiers = sponsorTiers.reduce<Record<Tiers, RawSponsor[]>>(
   (acc, tier) => ({ ...acc, [tier]: [] }),

--- a/app/screens/WelcomeScreen.tsx
+++ b/app/screens/WelcomeScreen.tsx
@@ -1,10 +1,11 @@
-import React from "react"
+import React, { useLayoutEffect } from "react"
 import { Dimensions, Image, ImageStyle, Platform, TextStyle, View, ViewStyle } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { Button, Screen, Text } from "../components"
 import { useAppNavigation } from "../hooks"
 import { AppStackScreenProps } from "../navigators"
 import { colors, spacing } from "../theme"
+import { prefetchScheduledEvents } from "../services/api"
 
 const welcomeLogo = require("../../assets/images/welcome-shapes.png")
 const { width: screenWidth } = Dimensions.get("screen")
@@ -17,6 +18,10 @@ export const WelcomeScreen: React.FC<WelcomeScreenProps> = (_props) => {
   function goNext() {
     navigation.navigate("Tabs", { screen: "Schedule" })
   }
+
+  useLayoutEffect(() => {
+    prefetchScheduledEvents()
+  }, [])
 
   return (
     <Screen style={$container}>

--- a/app/services/api/webflow-api.ts
+++ b/app/services/api/webflow-api.ts
@@ -13,6 +13,7 @@ import type {
   RawWorkshop,
 } from "./webflow-api.types"
 import {
+  CollectionConst,
   RECOMMENDATIONS,
   RECURRING_EVENTS,
   SCHEDULE,
@@ -38,105 +39,61 @@ const getCollectionById = async <T>(collectionId: string) => {
   return data.items
 }
 
-const useRecommendationsOptions = {
-  queryKey: [RECOMMENDATIONS.key, RECOMMENDATIONS.collectionId],
-  queryFn: async () => getCollectionById<RawRecommendations>(RECOMMENDATIONS.collectionId),
-} satisfies UseQueryOptions
+const webflowOptions = <Payload, Collection extends CollectionConst = CollectionConst>(
+  collection: Collection,
+) =>
+  ({
+    queryKey: [collection.key, collection.collectionId] as const,
+    queryFn: async () => getCollectionById<Payload>(collection.collectionId),
+  } satisfies UseQueryOptions)
 
-export const useRecommendations = () => {
-  return useQuery(useRecommendationsOptions)
-}
+const recommendationsOptions = webflowOptions<RawRecommendations>(RECOMMENDATIONS)
+export const useRecommendations = () => useQuery(recommendationsOptions)
 
-const useRecurringEventsOptions = {
-  queryKey: [RECURRING_EVENTS.key, RECURRING_EVENTS.collectionId],
-  queryFn: async () => getCollectionById<RawRecurringEvents>(RECURRING_EVENTS.collectionId),
-} satisfies UseQueryOptions
+const recurringEventsOptions = webflowOptions<RawRecurringEvents>(RECURRING_EVENTS)
+export const useRecurringEvents = () => useQuery(recurringEventsOptions)
 
-export const useRecurringEvents = () => {
-  return useQuery(useRecurringEventsOptions)
-}
+const speakersOptions = webflowOptions<RawSpeaker>(SPEAKERS)
+export const useSpeakers = () => useQuery(speakersOptions)
 
-const useSpeakersOptions = {
-  queryKey: [SPEAKERS.key, SPEAKERS.collectionId],
-  queryFn: async () => getCollectionById<RawSpeaker>(SPEAKERS.collectionId),
-} satisfies UseQueryOptions
+const speakerNamesOptions = webflowOptions<RawSpeakerName>(SPEAKER_NAMES)
+export const useSpeakerNames = () => useQuery(speakerNamesOptions)
 
-export const useSpeakers = () => {
-  return useQuery(useSpeakersOptions)
-}
-
-const useSpeakerNamesOptions = {
-  queryKey: [SPEAKER_NAMES.key, SPEAKER_NAMES.collectionId],
-  queryFn: async () => getCollectionById<RawSpeakerName>(SPEAKER_NAMES.collectionId),
-} satisfies UseQueryOptions
-
-export const useSpeakerNames = () => {
-  return useQuery(useSpeakerNamesOptions)
-}
-
-const useSponsorsOptions = {
-  queryKey: [SPONSORS.key, SPONSORS.collectionId],
-  queryFn: async () => getCollectionById<RawSponsor>(SPONSORS.collectionId),
-} satisfies UseQueryOptions
-
+const sponsorsOptions = webflowOptions<RawSponsor>(SPONSORS)
 export const useSponsors = () => {
-  const { data: sponsors, isLoading } = useQuery(useSponsorsOptions)
+  const { data: sponsors, ...rest } = useQuery(sponsorsOptions)
   const data = cleanedSponsors(sponsors)
 
-  return { isLoading, data }
+  return { data, ...rest }
 }
 
-const useTalksOptions = {
-  queryKey: [TALKS.key, TALKS.collectionId],
-  queryFn: async () => getCollectionById<RawTalk>(TALKS.collectionId),
-} satisfies UseQueryOptions
+const talksOptions = webflowOptions<RawTalk>(TALKS)
+export const useTalks = () => useQuery(talksOptions)
 
-export const useTalks = () => {
-  return useQuery(useTalksOptions)
-}
+const venuesOptions = webflowOptions<RawVenue>(VENUES)
+export const useVenues = () => useQuery(venuesOptions)
 
-const useVenuesOptions = {
-  queryKey: [VENUES.key, VENUES.collectionId],
-  queryFn: async () => getCollectionById<RawVenue>(VENUES.collectionId),
-} satisfies UseQueryOptions
+const workshopsOptions = webflowOptions<RawWorkshop>(WORKSHOPS)
+export const useWorkshops = () => useQuery(workshopsOptions)
 
-export const useVenues = () => {
-  return useQuery(useVenuesOptions)
-}
-
-const useWorkshopsOptions = {
-  queryKey: [WORKSHOPS.key, WORKSHOPS.collectionId],
-  queryFn: async () => getCollectionById<RawWorkshop>(WORKSHOPS.collectionId),
-} satisfies UseQueryOptions
-
-export const useWorkshops = () => {
-  return useQuery(useWorkshopsOptions)
-}
-
-const useScheduledEventsOptions = {
-  queryKey: [SCHEDULE.key, SCHEDULE.collectionId],
-  queryFn: async () => getCollectionById<RawScheduledEvent>(SCHEDULE.collectionId),
-} satisfies UseQueryOptions
-
-const useScheduledEventsQueries = [
-  useSpeakersOptions,
-  useWorkshopsOptions,
-  useRecurringEventsOptions,
-  useTalksOptions,
-  useScheduledEventsOptions,
+const scheduledEventsOptions = webflowOptions<RawScheduledEvent>(SCHEDULE)
+const scheduledEventsQueries = [
+  speakersOptions,
+  workshopsOptions,
+  recurringEventsOptions,
+  talksOptions,
+  scheduledEventsOptions,
 ] as const
-
 export const prefetchScheduledEvents = async () => {
   await Promise.all(
-    useScheduledEventsQueries.map(async (query) => {
+    scheduledEventsQueries.map(async (query) => {
       return queryClient.prefetchQuery(query)
     }),
   )
 }
-
 export const useScheduledEvents = () => {
   const queries = useQueries({
-    queries: useScheduledEventsQueries,
+    queries: scheduledEventsQueries,
   })
 
   const [speakers, workshops, recurringEvents, talks, scheduledEvents] = queries

--- a/app/services/api/webflow-consts.ts
+++ b/app/services/api/webflow-consts.ts
@@ -3,12 +3,12 @@ export const SITE_ID = "5ca38f35db5d2ea94aea469d"
 export const SPONSORS = {
   collectionId: "640a728fc24f8e73575fe189",
   key: "sponsors",
-}
+} as const
 
 export const SPEAKERS = {
   collectionId: "640a728fc24f8e94385fe188",
   key: "speakers",
-}
+} as const
 
 export const SPEAKER_NAMES = {
   collectionId: "640a728fc24f8e74d05fe18a",
@@ -23,32 +23,44 @@ export const WORKSHOPS = {
 export const SCHEDULE = {
   collectionId: "640a728fc24f8e63325fe185",
   key: "schedule",
-}
+} as const
 
 export const PAST_TALKS = {
   collectionId: "640a728fc24f8e76ef5fe186",
   key: "pastTalks",
-}
+} as const
 
 export const RECURRING_EVENTS = {
   collectionId: "640a728fc24f8e85a75fe18c",
   key: "recurringEvents",
-}
+} as const
 
 export const TALKS = {
   collectionId: "640a728fc24f8e31ee5fe18e",
   key: "talks",
-}
+} as const
 
 export const VENUES = {
   collectionId: "640a728fc24f8e553c5fe18d",
   key: "venues",
-}
+} as const
 
 export const RECOMMENDATIONS = {
   collectionId: "640a728fc24f8e083b5fe18f",
   key: "recommendations",
-}
+} as const
+
+export type CollectionConst =
+  | typeof SPONSORS
+  | typeof SPEAKERS
+  | typeof SPEAKER_NAMES
+  | typeof WORKSHOPS
+  | typeof SCHEDULE
+  | typeof PAST_TALKS
+  | typeof RECURRING_EVENTS
+  | typeof TALKS
+  | typeof VENUES
+  | typeof RECOMMENDATIONS
 
 // [NOTE] these keys probably have to change when webflow is updated
 // `/collections/${collectionId}` api will the keys

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "mocha": "6",
     "patch-package": "6.4.7",
     "postinstall-prepare": "1.0.1",
-    "prettier": "2.6.2",
+    "prettier": "2.8.7",
     "query-string": "^7.0.1",
     "react-devtools-core": "4.24.7",
     "reactotron-core-client": "^2.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11621,10 +11621,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-prettier@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@2.8.7:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
+  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
 
 pretty-bytes@5.6.0:
   version "5.6.0"


### PR DESCRIPTION
# Description

[Trello Card](145-prefetch-event-schedule-on-app-load)

One of the benefits of React Query is that we can have patterns like pre-populating a query cache so it seems like a transition is "instant".

This PR separates out `queryKeys` and `queryFns` from hooks so that we can prefetch the event schedule queries on the initial welcome screen. That way, when the user clicks to the event schedule, it feels instantaneous because the data has already been fetched.

This PR also updates Prettier because the existing version had an issue parsing the `satisifies` TypeScript keyword. `yarn format` was also run which updated a few unrelated screens.

# Graphics

The webflow network request in "Before" occur only once the user navigates to the event schedule screen. Whereas the network requests in "After" occur as soon as the app loads.

| Before            | After            |
| -------------- | ------------------ |
|  <video src="https://user-images.githubusercontent.com/37849890/231343209-2b2fd006-6f36-4ad5-aa36-8993de125ad4.mov" /> | <video src="https://user-images.githubusercontent.com/37849890/231343149-6a079591-9d64-4357-8194-8f44721f5ff6.mov" /> |


# Checklist:

- [x] I have done a thorough self-review of my code
- [x] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
