### PR TITLE
Added Webflow proxy

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -71,7 +71,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     eas: {
       projectId: "b72c79d7-7c87-4aa7-b964-998dcff69e07",
     },
-    webflowToken: "63eb6ae43b109a57f2f18438a50a2a91887f53dc238c700b332b0379e74cf616",
   },
   plugins: [
     "@react-native-firebase/app",

--- a/app/services/api/axios.ts
+++ b/app/services/api/axios.ts
@@ -1,4 +1,3 @@
-import Constants from "expo-constants"
 import axios from "axios"
 
 interface PaginatedData {
@@ -13,11 +12,11 @@ export type PaginatedItems<T> = PaginatedData & {
 }
 
 export const axiosInstance = axios.create({
-  baseURL: "https://api.webflow.com/",
+  baseURL: "https://chain-react-ai-chat.vercel.app/api/schedule/",
+  // baseURL: "http://localhost:3000/api/schedule/",
   headers: {
     "Content-Type": "application/json",
     "User-Agent": "Webflow Javascript SDK / 1.0",
-    Authorization: `Bearer ${Constants.expoConfig.extra.webflowToken}`,
   },
 })
 


### PR DESCRIPTION
# Description

This removes the Webflow API token from the app and instead points requests to an endpoint that proxies our requests to the Webflow API. This way, we do not leak secret in our client side bundle. The API endpoint has the Webflow token on the server and make requests to it on our behalf. It also caches the response from different collection endpoints to help with the API limit. The proxy server currently only fulfills requests to `/collections/*` to prevent using the token from searching for arbitrary endpoints

The previous token has been revoked, so we don't need to worry about scrubbing the git history.

[Trello Card](https://trello.com/c/W5iDohSh/155-remove-webflow-api-token)

Summary of the changes and any helpful notes for reviewers and testers.

# Graphics

n/a 

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
