### PR TITLE
Fixing Infinispin on initial load

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -63,7 +63,12 @@ const requestUserPermission = async () => {
 }
 
 export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
-  const { isLoading, schedules, refetch: refetchScheduleScreenData } = useScheduleScreenData()
+  const {
+    isLoading,
+    isRefetching,
+    schedules,
+    refetch: refetchScheduleScreenData,
+  } = useScheduleScreenData()
   const [selectedSchedule, setSelectedSchedule] = React.useState<Schedule>(schedules[0])
 
   useHeader({ title: formatDate(selectedSchedule.date, "EE, MMMM dd") }, [selectedSchedule])
@@ -230,7 +235,7 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
           refreshControl={
             <RefreshControl
               onRefresh={refetchScheduleScreenData}
-              refreshing={isLoading}
+              refreshing={isRefetching}
               tintColor={colors.palette.neutral100}
             />
           }

--- a/app/services/api/webflow-api.ts
+++ b/app/services/api/webflow-api.ts
@@ -91,6 +91,7 @@ export const useScheduledEvents = () => {
     SCHEDULE.collectionId,
     !isLoading && !!speakers && !!workshops && !!recurringEvents && !!talks,
   )
+
   return {
     data: cleanedSchedule({
       recurringEvents,
@@ -104,10 +105,11 @@ export const useScheduledEvents = () => {
 }
 
 export const useScheduleScreenData = () => {
-  const { data: events, isLoading, refetch } = useScheduledEvents()
+  const { data: events, isLoading, isRefetching, refetch } = useScheduledEvents()
 
   return {
     isLoading,
+    isRefetching,
     schedules: [
       {
         date: "2023-05-17",


### PR DESCRIPTION
# Description

On initial load, pull to refresh causes the refresh spinner to stick around instead of disappearing after the content is reloaded.

[Trello Card](159-infinispin-not-sure)
Fixes #131 

The `RefreshControl` had `refreshing` bound to `isLoading`. `isLoading` is only used for initial hard load. Using `refetch` would never update that state. Instead we are now binding `refreshing` to `isRefetching` to correctly indicate the status.

# Graphics

| Before            | After            |
| -------------- | ------------------ |
| <video src="https://user-images.githubusercontent.com/151139/233106938-3c63aa45-c344-4b6a-8846-cafb9c7520c5.mp4" /> | <video src="https://user-images.githubusercontent.com/151139/233107487-fd8a48ef-bb07-46c6-9982-9a6b2a973ec0.mp4" /> |
| | <video src="https://user-images.githubusercontent.com/151139/233107906-3546ea1f-02ab-4d45-981c-70123e622e93.mov" /> |




# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
