### PR TITLE
(fix) Schedule Cards

### DIFF
--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -93,6 +93,7 @@ const en = {
   scheduleScreen: {
     talkRecordingPosted: "Talk recording posted",
     videoComingSoon: "Video coming soon",
+    workshopBanner: "Events for workshop ticket-holders",
   },
 }
 

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -47,19 +47,21 @@ const TalkCTA = ({ talkUrl }: { talkUrl?: string }) =>
 const Footer = ({ heading, subheading, isPast, talkUrl, variant }: FooterProps) => {
   return (
     <View style={$footerContainer}>
-      <Text preset="cardFooterHeading" style={isPast ? $pastFooterHeading : $footerHeading}>
+      <Text
+        preset="cardFooterHeading"
+        style={isPast ? $pastFooterHeading : heading.length > 0 ? $footerHeading : {}}
+      >
         {heading}
       </Text>
       {isPast ? (
         <>
           <Text style={$pastFooterSubheading}>{subheading}</Text>
-          {
+          {talkUrl ??
             // assuming there will be other variants in the future I went with a switch statement
             {
               talk: <TalkCTA talkUrl={talkUrl} />,
               "speaker-panel": <TalkCTA talkUrl={talkUrl} />,
-            }[variant]
-          }
+            }[variant]}
         </>
       ) : (
         <Text style={$footerSubheading}>{subheading}</Text>
@@ -134,6 +136,15 @@ interface SpeakingEventProps {
   variant: Variants
 }
 
+interface RecurringEventProps {
+  heading: string
+  subheading: string
+  isPast?: boolean
+  sources: string[]
+  eventTitle: string
+  variant: Variants
+}
+
 interface BaseEventProps {
   formattedStartTime: string
   formattedEndTime?: string
@@ -187,6 +198,30 @@ const baseSpeakingEventProps = ({
   }
 }
 
+const baseRecurringEventProps = ({
+  heading,
+  subheading,
+  isPast,
+  sources,
+  eventTitle,
+  variant,
+}: RecurringEventProps) => {
+  const props = {
+    preset: eventTitle,
+    sources: sources.map((source) => ({ uri: source })),
+  } as AvatarProps
+  return {
+    // content: subheading,
+    contentStyle: isPast ? $pastContentText : $contentText,
+    RightComponent: (
+      <View style={$rightContainer}>
+        <Avatar style={$avatar} {...props} />
+      </View>
+    ),
+    FooterComponent: <Footer {...{ subheading, isPast, heading, variant }} />,
+  }
+}
+
 const ScheduleCard: FC<ScheduleCardProps> = (props) => {
   const {
     variant = "recurring",
@@ -217,7 +252,7 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
   }
   const variantProps =
     variant === "recurring"
-      ? { content: subheading, contentStyle: isPast ? $pastContentText : $contentText }
+      ? baseRecurringEventProps({ subheading, isPast, sources, eventTitle, heading, variant })
       : variant === "party"
       ? {
           content: subheading,

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -70,7 +70,7 @@ const Footer = ({ heading, subheading, isPast, talkUrl, variant }: FooterProps) 
   )
 }
 
-export type Variants = "workshop" | "talk" | "party" | "recurring" | "speaker-panel"
+export type Variants = "workshop" | "talk" | "party" | "recurring" | "speaker-panel" | "trivia-show"
 
 export interface ScheduleCardProps {
   /**
@@ -134,6 +134,7 @@ interface SpeakingEventProps {
   startTime?: string
   talkUrl?: string
   variant: Variants
+  isClickable: boolean
 }
 
 interface RecurringEventProps {
@@ -177,6 +178,7 @@ const baseSpeakingEventProps = ({
   startTime,
   talkUrl,
   variant,
+  isClickable,
 }: SpeakingEventProps) => {
   const props = {
     preset: eventTitle,
@@ -186,12 +188,14 @@ const baseSpeakingEventProps = ({
     RightComponent: (
       <View style={$rightContainer}>
         <Avatar style={$avatar} {...props} />
-        <Icon
-          icon="arrow"
-          size={24}
-          color={colors.palette.primary500}
-          containerStyle={$arrowContainer}
-        />
+        {isClickable && (
+          <Icon
+            icon="arrow"
+            size={24}
+            color={colors.palette.primary500}
+            containerStyle={$arrowContainer}
+          />
+        )}
       </View>
     ),
     FooterComponent: <Footer {...{ heading, subheading, isPast, startTime, talkUrl, variant }} />,
@@ -211,7 +215,6 @@ const baseRecurringEventProps = ({
     sources: sources.map((source) => ({ uri: source })),
   } as AvatarProps
   return {
-    // content: subheading,
     contentStyle: isPast ? $pastContentText : $contentText,
     RightComponent: (
       <View style={$rightContainer}>
@@ -237,7 +240,9 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
     talkUrl,
   } = props
   const navigation = useAppNavigation()
-  const onPress = ["talk"].includes(variant)
+  const onPress = ["trivia-show"].includes(variant)
+    ? undefined
+    : ["talk"].includes(variant)
     ? () => navigation.navigate("TalkDetails", { scheduleId: id })
     : ["workshop"].includes(variant)
     ? () => navigation.navigate("WorkshopDetails", { scheduleId: id })
@@ -274,6 +279,7 @@ const ScheduleCard: FC<ScheduleCardProps> = (props) => {
           isPast,
           talkUrl,
           variant,
+          isClickable: !!onPress,
         })
 
   const isReversed = variant === "recurring" || variant === "party"

--- a/app/screens/ScheduleScreen/ScheduleCard.tsx
+++ b/app/screens/ScheduleScreen/ScheduleCard.tsx
@@ -49,7 +49,7 @@ const Footer = ({ heading, subheading, isPast, talkUrl, variant }: FooterProps) 
     <View style={$footerContainer}>
       <Text
         preset="cardFooterHeading"
-        style={isPast ? $pastFooterHeading : heading.length > 0 ? $footerHeading : {}}
+        style={isPast ? $pastFooterHeading : (heading ?? "").length > 0 ? $footerHeading : {}}
       >
         {heading}
       </Text>

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -202,9 +202,11 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
   const renderSchedule = React.useCallback(
     ({ index, item: schedule }: { index: number; item: Schedule }) => (
       <>
-        <View style={$workshopBanner}>
-          <Text style={$workshopBannerText}>{translate("scheduleScreen.workshopBanner")}</Text>
-        </View>
+        {index === 0 && (
+          <View style={$workshopBanner}>
+            <Text style={$workshopBannerText}>{translate("scheduleScreen.workshopBanner")}</Text>
+          </View>
+        )}
         <View style={[$container, { width }]}>
           <FlashList<ScheduleCardProps>
             data={schedule.events}

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -7,6 +7,7 @@ import {
   Dimensions,
   findNodeHandle,
   RefreshControl,
+  TextStyle,
 } from "react-native"
 import { FlashList, ContentStyle } from "@shopify/flash-list"
 import Animated, {
@@ -24,11 +25,12 @@ import { formatDate } from "../../utils/formatDate"
 import { useAppState } from "../../hooks"
 import { format, isAfter } from "date-fns"
 import { useScheduleScreenData } from "../../services/api/webflow-api"
-import { ScrollToButton, useScrollToEvent } from "../../components"
+import { ScrollToButton, Text, useScrollToEvent } from "../../components"
 import { useCurrentDate } from "../../hooks/useCurrentDate"
 import { isConferencePassed } from "../../utils/isConferencePassed"
 import * as Device from "expo-device"
 import messaging from "@react-native-firebase/messaging"
+import { translate } from "../../i18n"
 
 export interface Schedule {
   date: string
@@ -199,43 +201,48 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
 
   const renderSchedule = React.useCallback(
     ({ index, item: schedule }: { index: number; item: Schedule }) => (
-      <View style={[$container, { width }]}>
-        <FlashList<ScheduleCardProps>
-          data={schedule.events}
-          estimatedItemSize={242}
-          estimatedListSize={{ height: schedules.length * 242, width }}
-          // To achieve better performance, specify the type based on the item
-          getItemType={(item) => item.variant}
-          keyExtractor={(item) => item.id}
-          onViewableItemsChanged={handleViewableEventIndexChanged}
-          ref={scheduleListRefs[schedule.date]}
-          scrollEventThrottle={16}
-          showsVerticalScrollIndicator={false}
-          viewabilityConfig={{ itemVisiblePercentThreshold: 1, minimumViewTime: 100 }}
-          contentContainerStyle={
-            scheduleIndex === index && eventIndex !== 0 ? $list : $listWithoutButton
-          }
-          renderItem={({ item, index: itemIndex }) => (
-            <View style={$cardContainer}>
-              <ScheduleCard
-                {...item}
-                isPast={
-                  index < scheduleIndex ||
-                  (index === scheduleIndex && itemIndex < eventIndex) ||
-                  isConfOver
-                }
+      <>
+        <View style={$workshopBanner}>
+          <Text style={$workshopBannerText}>{translate("scheduleScreen.workshopBanner")}</Text>
+        </View>
+        <View style={[$container, { width }]}>
+          <FlashList<ScheduleCardProps>
+            data={schedule.events}
+            estimatedItemSize={242}
+            estimatedListSize={{ height: schedules.length * 242, width }}
+            // To achieve better performance, specify the type based on the item
+            getItemType={(item) => item.variant}
+            keyExtractor={(item) => item.id}
+            onViewableItemsChanged={handleViewableEventIndexChanged}
+            ref={scheduleListRefs[schedule.date]}
+            scrollEventThrottle={16}
+            showsVerticalScrollIndicator={false}
+            viewabilityConfig={{ itemVisiblePercentThreshold: 1, minimumViewTime: 100 }}
+            contentContainerStyle={
+              scheduleIndex === index && eventIndex !== 0 ? $list : $listWithoutButton
+            }
+            renderItem={({ item, index: itemIndex }) => (
+              <View style={$cardContainer}>
+                <ScheduleCard
+                  {...item}
+                  isPast={
+                    index < scheduleIndex ||
+                    (index === scheduleIndex && itemIndex < eventIndex) ||
+                    isConfOver
+                  }
+                />
+              </View>
+            )}
+            refreshControl={
+              <RefreshControl
+                onRefresh={refetchScheduleScreenData}
+                refreshing={isLoading}
+                tintColor={colors.palette.neutral100}
               />
-            </View>
-          )}
-          refreshControl={
-            <RefreshControl
-              onRefresh={refetchScheduleScreenData}
-              refreshing={isLoading}
-              tintColor={colors.palette.neutral100}
-            />
-          }
-        />
-      </View>
+            }
+          />
+        </View>
+      </>
     ),
     [scheduleIndex, eventIndex, isConfOver, isFocused],
   )
@@ -297,4 +304,14 @@ const $listWithoutButton: ContentStyle = {
 
 const $cardContainer: ViewStyle = {
   paddingBottom: spacing.large,
+}
+
+const $workshopBanner: ViewStyle = {
+  backgroundColor: colors.palette.primary400,
+  paddingHorizontal: spacing.large,
+  paddingVertical: spacing.extraSmall,
+}
+
+const $workshopBannerText: TextStyle = {
+  color: colors.palette.neutral800,
 }

--- a/app/screens/VenuesScreen/VenuesScreen.tsx
+++ b/app/screens/VenuesScreen/VenuesScreen.tsx
@@ -26,6 +26,17 @@ interface VenuesSection {
   title: string
 }
 
+const getVenueDate = (venueTag: string): string => {
+  switch (WEBFLOW_MAP.venueTag[venueTag]) {
+    case "Workshop":
+      return "May 17"
+    case "After Party":
+      return "May 18"
+    default:
+      return "May 18-19"
+  }
+}
+
 const useVenuesSections = (): {
   isLoading: boolean
   sections: Array<SectionListData<Array<VenuesSection>>>
@@ -45,13 +56,7 @@ const useVenuesSections = (): {
           sortedVenues?.map((venue) => ({
             imageSource: venue["venue-image-s"].map((image) => ({ uri: image.url })),
             title: venue.name,
-            subtitle: `${WEBFLOW_MAP.venueTag[venue.tag]} • ${
-              WEBFLOW_MAP.venueTag[venue.tag] === "Workshop"
-                ? "May 17"
-                : WEBFLOW_MAP.venueTag[venue.tag] === "After Party"
-                ? "May 18"
-                : "May 18-19"
-            }`,
+            subtitle: `${WEBFLOW_MAP.venueTag[venue.tag]} • ${getVenueDate(venue.tag)}`,
             body: `${venue["street-address"]}\n${venue["city-state-zip"]}`,
             cta: {
               text: translate("venuesScreen.openInMaps"),

--- a/app/screens/VenuesScreen/VenuesScreen.tsx
+++ b/app/screens/VenuesScreen/VenuesScreen.tsx
@@ -46,7 +46,11 @@ const useVenuesSections = (): {
             imageSource: venue["venue-image-s"].map((image) => ({ uri: image.url })),
             title: venue.name,
             subtitle: `${WEBFLOW_MAP.venueTag[venue.tag]} • ${
-              WEBFLOW_MAP.venueTag[venue.tag] === "Workshop" ? "May 17" : "May 18-19"
+              WEBFLOW_MAP.venueTag[venue.tag] === "Workshop"
+                ? "May 17"
+                : WEBFLOW_MAP.venueTag[venue.tag] === "After Party"
+                ? "May 18"
+                : "May 18-19"
             }`,
             body: `${venue["street-address"]}\n${venue["city-state-zip"]}`,
             cta: {

--- a/app/services/api/webflow-api.types.ts
+++ b/app/services/api/webflow-api.types.ts
@@ -37,6 +37,8 @@ export interface ScheduledEvent extends Item {
   "recurring-event"?: RecurringEvents
   "speaker-2"?: Speaker | RawSpeakerName
   "speaker-3"?: Speaker | RawSpeakerName
+  "event-title"?: string
+  "event-description"?: string
   day: "Wednesday" | "Thursday" | "Friday"
   talk?: Talk
   type?:
@@ -47,6 +49,7 @@ export interface ScheduledEvent extends Item {
     | "Recurring"
     | "Sponsored"
     | "Lightning Talk"
+    | "Trivia Show"
   workshop?: Workshop
   location?: string
 }

--- a/app/services/api/webflow-api.types.ts
+++ b/app/services/api/webflow-api.types.ts
@@ -37,6 +37,8 @@ export interface ScheduledEvent extends Item {
   "recurring-event"?: RecurringEvents
   "speaker-2"?: Speaker | RawSpeakerName
   "speaker-3"?: Speaker | RawSpeakerName
+  "speaker-2-2"?: Speaker | RawSpeakerName
+  "speaker-3-2"?: Speaker | RawSpeakerName
   "event-title"?: string
   "event-description"?: string
   day: "Wednesday" | "Thursday" | "Friday"

--- a/app/services/api/webflow-api.types.ts
+++ b/app/services/api/webflow-api.types.ts
@@ -36,6 +36,7 @@ export interface ScheduledEvent extends Item {
   "is-a-talk"?: boolean
   "recurring-event"?: RecurringEvents
   "speaker-2"?: Speaker | RawSpeakerName
+  "speaker-3"?: Speaker | RawSpeakerName
   day: "Wednesday" | "Thursday" | "Friday"
   talk?: Talk
   type?:

--- a/app/services/api/webflow-consts.ts
+++ b/app/services/api/webflow-consts.ts
@@ -120,4 +120,8 @@ export const WEBFLOW_MAP = {
     a5028d71ed9c315a6e9fa67778f2579d: "SightSee",
     f42e3ac1a464004c28d91ddf3945b654: "Unique/to/Portland",
   },
+  triviaShow: {
+    title: "Trivia Show",
+    variant: "trivia-show",
+  },
 } as const

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -186,7 +186,6 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
         subheading: schedule.talk?.name,
       } as ScheduleCardProps
       if (isTriviaShow) {
-        console.tron.log({ schedule })
         baseItems.variant = WEBFLOW_MAP.triviaShow.variant
         baseItems.eventTitle = WEBFLOW_MAP.triviaShow.title
         baseItems.subheading = schedule["event-description"]

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -38,6 +38,7 @@ export const cleanedSchedule = ({
       location: WEBFLOW_MAP.location[schedule.location],
       "recurring-event": recurringEvents?.find(({ _id }) => _id === schedule["recurring-event"]),
       "speaker-2": speakers?.find(({ _id }) => _id === schedule["speaker-2"]),
+      "speaker-3": speakers?.find(({ _id }) => _id === schedule["speaker-3"]),
       day: WEBFLOW_MAP.scheduleDay[schedule.day] ?? WEBFLOW_MAP.scheduleDay["2e399bc3"],
       talk: talks?.find((talk) => talk._id === schedule["talk-2"]),
       type: WEBFLOW_MAP.scheduleType[schedule["event-type"]],
@@ -141,9 +142,12 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
         formattedEndTime:
           schedule["end-time"] && !isTheSameTime && formatDate(schedule["end-time"], "h:mm aaa"),
         eventTitle: schedule["recurring-event"]?.name ?? schedule["event-title"] ?? schedule.name,
-        heading: schedule["recurring-event"]?.["speaker-s"]?.map((s) => s.name).join(", ") ?? "",
+        heading:
+          schedule["recurring-event"]?.["speaker-s"]?.map((s) => s.name).join(", ") ??
+          schedule["speaker-3"]?.name ??
+          "",
         subheading: schedule["recurring-event"]?.["event-description"],
-        sources: [],
+        sources: schedule["speaker-3"] ? [schedule["speaker-3"]["speaker-photo"].url] : [],
         id: schedule._id,
       }
     case "Party":

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -41,6 +41,8 @@ export const cleanedSchedule = ({
         "recurring-event": recurringEvents?.find(({ _id }) => _id === schedule["recurring-event"]),
         "speaker-2": speakers?.find(({ _id }) => _id === schedule["speaker-2"]),
         "speaker-3": speakers?.find(({ _id }) => _id === schedule["speaker-3"]),
+        "speaker-2-2": speakers?.find(({ _id }) => _id === schedule["speaker-2-2"]),
+        "speaker-3-2": speakers?.find(({ _id }) => _id === schedule["speaker-3-2"]),
         day: WEBFLOW_MAP.scheduleDay[schedule.day] ?? WEBFLOW_MAP.scheduleDay["2e399bc3"],
         talk: talks?.find((talk) => talk._id === schedule["talk-2"]),
         type: isTriviaShow
@@ -179,13 +181,29 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
         sources: schedule.talk?.["speaker-s"]?.map((s) => s["speaker-photo"]?.url) ?? [],
         id: schedule._id,
         talkUrl: schedule.talk?.["talk-url"],
+        variant: "talk",
+        eventTitle: schedule.type,
+        subheading: schedule.talk?.name,
+      } as ScheduleCardProps
+      if (isTriviaShow) {
+        console.tron.log({ schedule })
+        baseItems.variant = WEBFLOW_MAP.triviaShow.variant
+        baseItems.eventTitle = WEBFLOW_MAP.triviaShow.title
+        baseItems.subheading = schedule["event-description"]
+        baseItems.sources = [
+          schedule["speaker-2-2"]?.["speaker-photo"].url,
+          schedule["speaker-3"]?.["speaker-photo"].url,
+          schedule["speaker-3-2"]?.["speaker-photo"].url,
+        ].filter(Boolean)
+        baseItems.heading = [
+          schedule["speaker-2-2"]?.name,
+          schedule["speaker-3"]?.name,
+          schedule["speaker-3-2"]?.name,
+        ]
+          .filter(Boolean)
+          .join(", ")
       }
-      return {
-        ...baseItems,
-        variant: isTriviaShow ? WEBFLOW_MAP.triviaShow.variant : "talk",
-        eventTitle: isTriviaShow ? WEBFLOW_MAP.triviaShow.title : schedule.type,
-        subheading: isTriviaShow ? schedule["event-description"] : schedule.talk?.name,
-      }
+      return baseItems
     case "Speaker Panel":
       return {
         variant: "speaker-panel",

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -195,8 +195,11 @@ const convertScheduleToCardProps = (schedule: ScheduledEvent): ScheduleCardProps
         startTime: schedule["day-time"],
         eventTitle: "workshop",
         heading: workshop?.name,
-        subheading: workshop?.["instructor-info"]?.name,
-        sources: [workshop?.["instructor-info"]?.["speaker-photo"]?.url],
+        subheading:
+          workshop?.["instructor-s-2"]?.map((instructor) => instructor.name).join(", ") ??
+          workshop?.["instructor-info"]?.name,
+        sources:
+          workshop?.["instructor-s-2"]?.map((instructor) => instructor["speaker-photo"].url) ?? [],
         level: workshop?.level,
         id: schedule._id,
       }


### PR DESCRIPTION
# Description

[Trello Card](160-welcome-card) — #128 
[Trello Card](162-trivia-card) — #130 
[Trello Card](166-after-party-is-may-18-dont-include-the-19th) — #132 
[Trello Card](167-workshops-disclaimer) — #138 

Several changes here:
1. The `Welcome` card now better highlights our emcee, Ken LaFrance
2. The `Trivia Card` is now a thing (`variant` and all)
3. Fixed the After Party date on the `Venues` tab
4. Added a Workshops disclaimer on the `Wed` tab on the `Schedule` tab

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <img width="300" src="https://user-images.githubusercontent.com/9324607/233157523-9d23c3d0-3e83-40a1-ac4d-421456171c40.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233157658-925b71f8-1b84-4866-b55a-621574021131.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233157832-88ecf68e-c028-44c0-8463-e38219fae984.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233158025-187c198b-d0ff-41a5-8486-64a0821131be.png" /> | <img width="300" src="https://user-images.githubusercontent.com/9324607/233157596-dc8cde68-278b-4b3b-bad1-d488fb3c96ba.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233157708-93aedf45-f9cf-4be9-9f8b-f6edb334635a.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233157802-805a566b-467b-414d-9c73-1f2621505963.png" /><br/><img width="300" src="https://user-images.githubusercontent.com/9324607/233157934-66f7feba-ecaa-452d-9a74-cd5f6921115b.png" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
