### PR TITLE
(fix) `Explore` Custom Sort

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -40,6 +40,20 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: "#081828",
     },
     googleServicesFile: `./google-services.json`,
+    intentFilters: [
+      {
+        action: "VIEW",
+        data: { scheme: "https" },
+      },
+      {
+        action: "VIEW",
+        data: { scheme: "google.navigation" },
+      },
+      {
+        action: "VIEW",
+        data: { scheme: "geo" },
+      },
+    ],
   },
   ios: {
     icon: "./assets/images/app-icon-ios.png",

--- a/app/components/ButtonLink.tsx
+++ b/app/components/ButtonLink.tsx
@@ -8,9 +8,10 @@ type Props = {
   children: string
   style?: ViewStyle
   openLink: string | ((event: GestureResponderEvent) => void)
+  preset?: "link" | "reversed" // "default" is not supported
 }
 
-export const ButtonLink: FC<Props> = ({ children, style, ...props }) => {
+export const ButtonLink: FC<Props> = ({ children, style, preset = "link", ...props }) => {
   const openLink = (e: GestureResponderEvent) => {
     if (typeof props.openLink === "function") {
       props.openLink(e)
@@ -21,7 +22,7 @@ export const ButtonLink: FC<Props> = ({ children, style, ...props }) => {
 
   return (
     <Button
-      preset="link"
+      preset={preset}
       onPress={openLink}
       accessibilityRole="link"
       style={style}

--- a/app/components/ButtonLink.tsx
+++ b/app/components/ButtonLink.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from "react"
-import { GestureResponderEvent, Linking, ViewStyle } from "react-native"
+import { GestureResponderEvent, ViewStyle } from "react-native"
 import { Button } from "./Button"
 import { AutoImage } from "./AutoImage"
 import { spacing } from "../theme"
+import { openLinkInBrowser } from "../utils/openLinkInBrowser"
 
 type Props = {
   children: string
@@ -17,7 +18,7 @@ export const ButtonLink: FC<Props> = ({ children, style, preset = "link", ...pro
       props.openLink(e)
       return
     }
-    Linking.openURL(props.openLink)
+    openLinkInBrowser(props.openLink)
   }
 
   return (

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -37,6 +37,7 @@ const en = {
     uniqueToPortland: "Unique to Portland",
     openInMaps: "Open in maps",
     website: "Website",
+    wantToSeeMore: "Want to see more places? Open this map!",
   },
   tabNavigator: {
     scheduleTab: "Schedule",

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -14,9 +14,9 @@ import { useHeader } from "../../hooks/useHeader"
 import { translate } from "../../i18n"
 import { useRecommendations } from "../../services/api"
 import { WEBFLOW_MAP } from "../../services/api/webflow-consts"
-import { groupBy } from "../../services/api/webflow-helpers"
 import { RawRecommendations } from "../../services/api/webflow-api.types"
 import { DynamicCarouselItem } from "../../components/carousel/carousel.types"
+import { groupBy } from "../../utils/groupBy"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
 type RecommendationType = typeof recommendationTypes[number]

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -113,6 +113,7 @@ export const ExploreScreen: FC<TabScreenProps<"Explore">> = () => {
                 )
               }
               style={$buttonLink}
+              preset="reversed"
             >
               {translate("exploreScreen.wantToSeeMore")}
             </ButtonLink>

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -17,6 +17,7 @@ import { WEBFLOW_MAP } from "../../services/api/webflow-consts"
 import { RawRecommendations } from "../../services/api/webflow-api.types"
 import { DynamicCarouselItem } from "../../components/carousel/carousel.types"
 import { groupBy } from "../../utils/groupBy"
+import { customSortObjectKeys } from "../../utils/customSort"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
 type RecommendationType = typeof recommendationTypes[number]
@@ -61,10 +62,11 @@ const useRecommendationSections = (): {
     }),
     initialRecs,
   )
+  const sortedRecs = customSortObjectKeys(recs, ["Food/Drink", "Unique/to/Portland"])
 
   return {
     isLoading,
-    sections: Object.entries(recs).map(
+    sections: Object.entries(sortedRecs).map(
       ([key, value]: [RecommendationType, RawRecommendations[]]) => ({
         title: sectionTitle(key),
         renderItem: RenderItem,
@@ -128,7 +130,6 @@ const $activityIndicator: ViewStyle = {
 }
 
 const $heading: TextStyle = {
-  marginTop: spacing.large,
   marginBottom: spacing.medium,
   paddingHorizontal: spacing.large,
 }

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react"
 import {
   ActivityIndicator,
+  Linking,
   SectionList,
   SectionListData,
   TextStyle,
@@ -18,7 +19,6 @@ import { RawRecommendations } from "../../services/api/webflow-api.types"
 import { DynamicCarouselItem } from "../../components/carousel/carousel.types"
 import { groupBy } from "../../utils/groupBy"
 import { customSortObjectKeys } from "../../utils/customSort"
-import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
 type RecommendationType = typeof recommendationTypes[number]
@@ -108,8 +108,8 @@ export const ExploreScreen: FC<TabScreenProps<"Explore">> = () => {
           ListFooterComponent={
             <ButtonLink
               openLink={() =>
-                openLinkInBrowser(
-                  "https://www.google.com/maps/d/u/0/viewer?mid=1QWdKaK186ufwRQR2m_oGSOIiRVMRjSs&hl=en_US&ll=45.52275389785826%2C-122.67765992521456&z=16",
+                Linking.openURL(
+                  "https://www.google.com/maps/d/viewer?mid=1QWdKaK186ufwRQR2m_oGSOIiRVMRjSs&hl=en_US&ll=45.52275389785826%2C-122.67765992521456&z=16",
                 )
               }
               style={$buttonLink}

--- a/app/screens/ExploreScreen/ExploreScreen.tsx
+++ b/app/screens/ExploreScreen/ExploreScreen.tsx
@@ -7,7 +7,7 @@ import {
   View,
   ViewStyle,
 } from "react-native"
-import { Carousel, Screen, Text } from "../../components"
+import { ButtonLink, Carousel, Screen, Text } from "../../components"
 import { TabScreenProps } from "../../navigators/TabNavigator"
 import { colors, spacing } from "../../theme"
 import { useHeader } from "../../hooks/useHeader"
@@ -18,6 +18,7 @@ import { RawRecommendations } from "../../services/api/webflow-api.types"
 import { DynamicCarouselItem } from "../../components/carousel/carousel.types"
 import { groupBy } from "../../utils/groupBy"
 import { customSortObjectKeys } from "../../utils/customSort"
+import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
 
 const recommendationTypes = Object.values(WEBFLOW_MAP.recommendationType)
 type RecommendationType = typeof recommendationTypes[number]
@@ -104,6 +105,18 @@ export const ExploreScreen: FC<TabScreenProps<"Explore">> = () => {
       )}
       {!isLoading && sections.length > 0 && (
         <SectionList
+          ListFooterComponent={
+            <ButtonLink
+              openLink={() =>
+                openLinkInBrowser(
+                  "https://www.google.com/maps/d/u/0/viewer?mid=1QWdKaK186ufwRQR2m_oGSOIiRVMRjSs&hl=en_US&ll=45.52275389785826%2C-122.67765992521456&z=16",
+                )
+              }
+              style={$buttonLink}
+            >
+              {translate("exploreScreen.wantToSeeMore")}
+            </ButtonLink>
+          }
           stickySectionHeadersEnabled={false}
           sections={sections}
           renderSectionHeader={({ section: { title, data } }) =>
@@ -136,4 +149,9 @@ const $heading: TextStyle = {
 
 const $carouselWrapper: ViewStyle = {
   marginBottom: spacing.large,
+}
+
+const $buttonLink: ViewStyle = {
+  marginBottom: spacing.large,
+  marginHorizontal: spacing.large,
 }

--- a/app/screens/InfoScreen/OurSponsorsScreen.tsx
+++ b/app/screens/InfoScreen/OurSponsorsScreen.tsx
@@ -13,9 +13,9 @@ import { useAppNavigation, useHeader } from "../../hooks"
 import { useSponsors } from "../../services/api"
 import { RawSponsor } from "../../services/api/webflow-api.types"
 import { WEBFLOW_MAP } from "../../services/api/webflow-consts"
-import { groupBy } from "../../services/api/webflow-helpers"
 import { colors, spacing } from "../../theme"
 import { SponsorCard } from "./SponsorCard"
+import { groupBy } from "../../utils/groupBy"
 
 const sponsorTiers = Object.values(WEBFLOW_MAP.sponsorTier)
 type Tiers = typeof sponsorTiers[number]

--- a/app/services/api/webflow-helpers.ts
+++ b/app/services/api/webflow-helpers.ts
@@ -1,5 +1,6 @@
 import { ScheduleCardProps } from "../../screens/ScheduleScreen/ScheduleCard"
 import { formatDate, sortByTime } from "../../utils/formatDate"
+import { groupBy } from "../../utils/groupBy"
 import type {
   RawScheduledEvent,
   RawSpeaker,
@@ -247,15 +248,3 @@ export const convertScheduleToScheduleCard = (
   const daySchedule: ScheduledEvent[] = groupBy("day")(scheduleData ?? [])?.[day] ?? []
   return daySchedule.sort(sortByTime).map(convertScheduleToCardProps).filter(Boolean)
 }
-
-// [NOTE] util function that might be needed in the future
-export const groupBy =
-  (key: string) =>
-  <T>(array: T[]) =>
-    array.reduce(
-      (objectsByKeyValue, obj) => ({
-        ...objectsByKeyValue,
-        [obj[key]]: (objectsByKeyValue[obj[key]] || []).concat(obj),
-      }),
-      {},
-    )

--- a/app/utils/customSort.ts
+++ b/app/utils/customSort.ts
@@ -49,3 +49,47 @@ export const customSort = <T extends SortableObject>(
     }
   })
 }
+
+/**
+ * Sorts an object's keys by a given order
+ * 
+ * @param obj—object to sort
+ * @param order—array of keys to sort by
+ * 
+ * @example
+ * ```tsx
+ * const recommendations = customSortObjectKeys(
+ *  {
+ *    "Food/Drink": [],
+ *    "Unique/to/Portland": [],
+ *    "SightSee": []
+ *  },
+ *  ["SightSee", "Food/Drink", "Unique/to/Portland"]
+ * )
+ * ```
+ * output:
+ * ```tsx
+ * recommendations = {
+ *  "SightSee": [],
+ *  "Food/Drink": [],
+ *  "Unique/to/Portland": []
+ * }
+  ```
+ */
+export const customSortObjectKeys = <T extends Record<string, any>>(
+  obj: T,
+  order: Array<keyof T>,
+): T => {
+  const sortedObj = {} as T
+  for (const key of order) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      sortedObj[key] = obj[key]
+    }
+  }
+  for (const key in obj) {
+    if (!Object.prototype.hasOwnProperty.call(sortedObj, key)) {
+      sortedObj[key] = obj[key]
+    }
+  }
+  return sortedObj
+}

--- a/app/utils/customSort.ts
+++ b/app/utils/customSort.ts
@@ -2,6 +2,30 @@ interface SortableObject {
   [key: string]: any
 }
 
+/**
+ *
+ * @param arr—array of objects to sort
+ * @param property—key of the object to sort by
+ * @param order—array of keys to sort by
+ * @returns sorted array
+ *
+ * @example
+ * ```tsx
+ * const sortedVenues = customSort(venues, "slug", [
+ *   "the-armory",
+ *   "after-party-expensify-office",
+ *   "courtyard-portland-city-center",
+ * ])
+ * ```
+ * output:
+ * ```tsx
+ * sortedVenues = [
+ *  {}, // "the-armory"
+ *  {}, // "after-party-expensify-office"
+ *  {}, // "courtyard-portland-city-center"
+ *  ... // other venues
+ * ]
+ */
 export const customSort = <T extends SortableObject>(
   arr: T[],
   property: keyof T,

--- a/app/utils/groupBy.ts
+++ b/app/utils/groupBy.ts
@@ -1,0 +1,10 @@
+export const groupBy =
+  (key: string) =>
+  <T>(array: T[]) =>
+    array.reduce(
+      (objectsByKeyValue, obj) => ({
+        ...objectsByKeyValue,
+        [obj[key]]: (objectsByKeyValue[obj[key]] || []).concat(obj),
+      }),
+      {},
+    )

--- a/app/utils/groupBy.ts
+++ b/app/utils/groupBy.ts
@@ -1,3 +1,29 @@
+/**
+ *
+ * @param key string—the key to group by
+ * @returns an object with the grouped values, keyed by the value of the key
+ *
+ * @example
+ * ```tsx
+ * const grouped = groupBy('id')([
+ *  { type: "Food/Drink", name: 'Starbucks Reserve' },
+ *  { type: "Unique/to/Portland", name: 'Ground Kontrol Arcade' },
+ *  { type: "Food/Drink", name: 'Hotel Restaurant - The Original Dinerant' },
+ * ])
+ * ```
+ * output:
+ * ```tsx
+ * grouped = {
+ *  "Food/Drink": [
+ *    { type: "Food/Drink", name: 'Starbucks Reserve' },
+ *    { type: "Food/Drink", name: 'Hotel Restaurant - The Original Dinerant' },
+ *  ],
+ *  "Unique/to/Portland": [
+ *    { type: "Unique/to/Portland", name: 'Ground Kontrol Arcade' },
+ *  ]
+ * }
+ * ```
+ */
 export const groupBy =
   (key: string) =>
   <T>(array: T[]) =>

--- a/app/utils/openLinkInBrowser.ts
+++ b/app/utils/openLinkInBrowser.ts
@@ -4,5 +4,8 @@ import { Linking } from "react-native"
  * Helper for opening a give URL in an external browser.
  */
 export function openLinkInBrowser(url: string) {
-  Linking.canOpenURL(url).then((canOpen) => canOpen && Linking.openURL(url))
+  Linking.canOpenURL(url).then((canOpen) => {
+    console.tron.log({ canOpen })
+    if (canOpen) Linking.openURL(url)
+  })
 }

--- a/app/utils/openMap.tsx
+++ b/app/utils/openMap.tsx
@@ -3,7 +3,7 @@ import { Linking, Platform } from "react-native"
 export const openMap = async (address: string) => {
   const destination = encodeURIComponent(address)
   const provider = Platform.OS === "ios" ? "apple" : "google"
-  const link = `http://maps.${provider}.com/?daddr=${destination}`
+  const link = `https://maps.${provider}.com/?daddr=${destination}`
 
   try {
     // TODO come back here for canOpenURL and properly implement AndroidManifest.xml


### PR DESCRIPTION
# Description

[Trello Card](154-explore-custom-sort-order) — #118 
[Trello Card](170-feature-request-advanced-map-link) — #133 

- adding a custom sort function for objects by its keys
- sorting the `Explore` tab
- Advanced Map Link on `Explore` tab (feature request)

# Graphics

| iOS | Android |
| ---- | ---- |
| <img width="300" src="https://user-images.githubusercontent.com/9324607/233421044-354d984f-406d-49c3-be11-3ecf1b4c513e.png" /> | <img width="300" src="https://user-images.githubusercontent.com/9324607/233420986-d3fb4d3a-3571-4c42-8901-081febb38b8c.png" />

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
