### PR TITLE
(fix) Talk Details screen

### DIFF
--- a/app/components/SocialButton.tsx
+++ b/app/components/SocialButton.tsx
@@ -47,8 +47,12 @@ interface SocialButtonsProps {
 
 export const SocialButtons = ({ socialButtons }: SocialButtonsProps) => (
   <>
-    {socialButtons.map((socialButtonProps) => (
-      <SocialButton {...socialButtonProps} key={socialButtonProps.url} style={$socialButtons} />
+    {socialButtons.map((socialButtonProps, index) => (
+      <SocialButton
+        {...socialButtonProps}
+        key={`${socialButtonProps.icon}-${index}`}
+        style={$socialButtons}
+      />
     ))}
   </>
 )

--- a/app/components/SocialButton.tsx
+++ b/app/components/SocialButton.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Pressable, PressableProps, StyleProp, ViewStyle } from "react-native"
+import { spacing } from "../theme"
 import { openLinkInBrowser } from "../utils/openLinkInBrowser"
 import { Icon, IconProps } from "./Icon"
 
@@ -23,7 +24,7 @@ export interface SocialButtonProps extends PressableProps {
 }
 
 export function SocialButton(props: SocialButtonProps) {
-  const { size, url, icon, style: $styleOverride, ...rest } = props
+  const { size = 24, url, icon, style: $styleOverride, ...rest } = props
 
   if (!url) return null
 
@@ -40,6 +41,18 @@ export function SocialButton(props: SocialButtonProps) {
   )
 }
 
+interface SocialButtonsProps {
+  socialButtons: Array<SocialButtonProps>
+}
+
+export const SocialButtons = ({ socialButtons }: SocialButtonsProps) => (
+  <>
+    {socialButtons.map((socialButtonProps) => (
+      <SocialButton {...socialButtonProps} key={socialButtonProps.url} style={$socialButtons} />
+    ))}
+  </>
+)
+
 const $socialButton: ViewStyle = {
   backgroundColor: "#1C2B3D",
   width: 42,
@@ -47,4 +60,8 @@ const $socialButton: ViewStyle = {
   borderRadius: 21,
   alignItems: "center",
   justifyContent: "center",
+}
+
+const $socialButtons: ViewStyle = {
+  marginEnd: spacing.medium,
 }

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -90,7 +90,6 @@ const en = {
   talkDetailsScreen: {
     watchTalk: "Watch talk",
     assistingTheWorkshop: "Assisting the workshop",
-    comingSoon: "Coming soon",
   },
   workshopDetailsScreen: {
     instructor: {

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -88,6 +88,7 @@ const en = {
   talkDetailsScreen: {
     watchTalk: "Watch talk",
     assistingTheWorkshop: "Assisting the workshop",
+    comingSoon: "Coming soon",
   },
   workshopDetailsScreen: {
     instructor: {

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -3,6 +3,7 @@ const en = {
     ok: "OK!",
     cancel: "Cancel",
     back: "Back",
+    comingSoon: "Coming soon",
   },
   welcomeScreen: {
     heading: "Welcome to Chain React!",

--- a/app/screens/TalkDetailsScreen/AssistantsList.tsx
+++ b/app/screens/TalkDetailsScreen/AssistantsList.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { ImageStyle, TextStyle, View, ViewStyle } from "react-native"
-import { AutoImage, IconButton, Text } from "../../components"
-import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
+import { AutoImage, Text } from "../../components"
 import { translate } from "../../i18n"
 import { colors, spacing } from "../../theme"
 import { Speaker } from "../../services/api/webflow-api.types"
+import { SocialButton } from "../../components/SocialButton"
 
 export interface AssistantsListProp {
   assistants: Speaker[]
@@ -32,9 +32,23 @@ export function AssistantsList(props: AssistantsListProp) {
               <Text preset="companionHeading" text={assistant.name} />
               <Text preset="label" style={$assistantCompany} text={assistant.company} />
               <View style={$assistantLinks}>
-                <IconButton
-                  icon={assistant.twitter ? "twitter" : "link"}
-                  onPress={() => openLinkInBrowser(assistant.twitter || assistant.externalURL)}
+                <SocialButton
+                  icon={"twitter"}
+                  style={$socialButton}
+                  url={assistant.twitter}
+                  size={24}
+                />
+                <SocialButton
+                  icon={"github"}
+                  style={$socialButton}
+                  url={assistant.github}
+                  size={24}
+                />
+                <SocialButton
+                  icon={"link"}
+                  style={$socialButton}
+                  url={assistant.externalURL}
+                  size={24}
                 />
               </View>
             </View>
@@ -85,4 +99,8 @@ const $assistantCompany: TextStyle = {
 const $assistantLinks: ViewStyle = {
   flexDirection: "row",
   marginTop: spacing.large,
+}
+
+const $socialButton: ViewStyle = {
+  marginEnd: spacing.medium,
 }

--- a/app/screens/TalkDetailsScreen/AssistantsList.tsx
+++ b/app/screens/TalkDetailsScreen/AssistantsList.tsx
@@ -4,7 +4,7 @@ import { AutoImage, Text } from "../../components"
 import { translate } from "../../i18n"
 import { colors, spacing } from "../../theme"
 import { Speaker } from "../../services/api/webflow-api.types"
-import { SocialButton } from "../../components/SocialButton"
+import { SocialButtons } from "../../components/SocialButton"
 
 export interface AssistantsListProp {
   assistants: Speaker[]
@@ -32,23 +32,12 @@ export function AssistantsList(props: AssistantsListProp) {
               <Text preset="companionHeading" text={assistant.name} />
               <Text preset="label" style={$assistantCompany} text={assistant.company} />
               <View style={$assistantLinks}>
-                <SocialButton
-                  icon={"twitter"}
-                  style={$socialButton}
-                  url={assistant.twitter}
-                  size={24}
-                />
-                <SocialButton
-                  icon={"github"}
-                  style={$socialButton}
-                  url={assistant.github}
-                  size={24}
-                />
-                <SocialButton
-                  icon={"link"}
-                  style={$socialButton}
-                  url={assistant.externalURL}
-                  size={24}
+                <SocialButtons
+                  socialButtons={[
+                    { icon: "twitter", url: assistant.twitter },
+                    { icon: "github", url: assistant.github },
+                    { icon: "link", url: assistant.externalURL },
+                  ]}
                 />
               </View>
             </View>
@@ -99,8 +88,4 @@ const $assistantCompany: TextStyle = {
 const $assistantLinks: ViewStyle = {
   flexDirection: "row",
   marginTop: spacing.large,
-}
-
-const $socialButton: ViewStyle = {
-  marginEnd: spacing.medium,
 }

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -85,9 +85,9 @@ const talkDetailsProps = (schedule: ScheduledEvent): TalkDetailsProps => {
     imageUrl: talk?.["speaker-s"][0]?.["speaker-photo"].url,
     fullName: talk?.["speaker-s"][0]?.name,
     company: talk?.["speaker-s"][0]?.company,
-    description: stringOrPlaceholder(talk?.description, "talkDetailsScreen.comingSoon"),
+    description: stringOrPlaceholder(talk?.description),
     firstName: talk?.["speaker-s"][0]["speaker-first-name"],
-    bio: stringOrPlaceholder(talk?.["speaker-s"][0]["speaker-bio"], "talkDetailsScreen.comingSoon"),
+    bio: stringOrPlaceholder(talk?.["speaker-s"][0]["speaker-bio"]),
     talkUrl: talk?.["talk-url"],
     eventTime: schedule["day-time"],
     socialButtons: [

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -4,14 +4,13 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { AppStackParamList } from "../../navigators"
 import {
   Text,
-  IconButton,
   MIN_HEADER_HEIGHT,
   BoxShadow,
   Screen,
   MediaButton,
+  IconProps,
 } from "../../components"
 import { colors, spacing } from "../../theme"
-import { openLinkInBrowser } from "../../utils/openLinkInBrowser"
 import { TalkDetailsHeader } from "./TalkDetailsHeader"
 import Animated from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -20,6 +19,7 @@ import { formatDate } from "../../utils/formatDate"
 import { isFuture, parseISO } from "date-fns"
 import { ScheduledEvent } from "../../services/api/webflow-api.types"
 import { useFloatingActionEvents, useScrollY } from "../../hooks"
+import { SocialButton } from "../../components/SocialButton"
 
 export type Variants = "workshop" | "talk"
 
@@ -64,6 +64,10 @@ export interface TalkDetailsProps {
    * The time of the event
    */
   eventTime: string
+  /**
+   * The social buttons of the speaker
+   */
+  socialButtons: Array<{ url: string; icon: IconProps["icon"] }>
 }
 
 const talkBlob = require("../../../assets/images/talk-shape.png")
@@ -85,13 +89,17 @@ const talkDetailsProps = (schedule: ScheduledEvent): TalkDetailsProps => {
     bio: talk?.["speaker-s"][0]["speaker-bio"],
     talkUrl: talk?.["talk-url"],
     eventTime: schedule["day-time"],
+    socialButtons: [
+      { url: talk?.["speaker-s"][0]?.twitter, icon: "twitter" },
+      { url: talk?.["speaker-s"][0]?.github, icon: "github" },
+      { url: talk?.["speaker-s"][0]?.externalURL, icon: "link" },
+    ],
   }
 }
 
 export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDetails">> = ({
   route: { params },
 }) => {
-  const onPress = (url) => openLinkInBrowser(url)
   const [headingHeight, setHeadingHeight] = React.useState(0)
 
   const { isScrolling, scrollHandlers } = useFloatingActionEvents()
@@ -114,6 +122,7 @@ export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDeta
     title,
     talkUrl,
     eventTime,
+    socialButtons,
   } = talkDetailsProps(schedule)
 
   const isEventPassed = !isFuture(parseISO(eventTime))
@@ -169,9 +178,15 @@ export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDeta
             </View>
 
             <View style={$linksContainer}>
-              <IconButton icon="twitter" onPress={() => onPress("https://cr.infinite.red")} />
-              <IconButton icon="github" onPress={() => onPress("https://cr.infinite.red")} />
-              <IconButton icon="link" onPress={() => onPress("https://cr.infinite.red")} />
+              {socialButtons.map((socialButton) => (
+                <SocialButton
+                  icon={socialButton.icon}
+                  key={socialButton.icon}
+                  style={$socialButton}
+                  url={socialButton.url}
+                  size={24}
+                />
+              ))}
             </View>
           </View>
         </Animated.ScrollView>
@@ -200,7 +215,6 @@ const $containerSpacing: ViewStyle = {
 
 const $linksContainer: ViewStyle = {
   flexDirection: "row",
-  justifyContent: "space-between",
   width: "50%",
 }
 
@@ -268,4 +282,8 @@ const $subtitle: TextStyle = {
 
 const $headingContainer: ViewStyle = {
   marginBottom: spacing.extraLarge,
+}
+
+const $socialButton: ViewStyle = {
+  marginEnd: spacing.medium,
 }

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -19,7 +19,7 @@ import { formatDate } from "../../utils/formatDate"
 import { isFuture, parseISO } from "date-fns"
 import { ScheduledEvent } from "../../services/api/webflow-api.types"
 import { useFloatingActionEvents, useScrollY } from "../../hooks"
-import { SocialButton } from "../../components/SocialButton"
+import { SocialButtons } from "../../components/SocialButton"
 import { translate } from "../../i18n"
 
 export type Variants = "workshop" | "talk"
@@ -182,15 +182,7 @@ export const TalkDetailsScreen: FC<StackScreenProps<AppStackParamList, "TalkDeta
             </View>
 
             <View style={$linksContainer}>
-              {socialButtons.map((socialButton) => (
-                <SocialButton
-                  icon={socialButton.icon}
-                  key={socialButton.icon}
-                  style={$socialButton}
-                  url={socialButton.url}
-                  size={24}
-                />
-              ))}
+              <SocialButtons socialButtons={socialButtons} />
             </View>
           </View>
         </Animated.ScrollView>
@@ -286,8 +278,4 @@ const $subtitle: TextStyle = {
 
 const $headingContainer: ViewStyle = {
   marginBottom: spacing.extraLarge,
-}
-
-const $socialButton: ViewStyle = {
-  marginEnd: spacing.medium,
 }

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -20,6 +20,7 @@ import { isFuture, parseISO } from "date-fns"
 import { ScheduledEvent } from "../../services/api/webflow-api.types"
 import { useFloatingActionEvents, useScrollY } from "../../hooks"
 import { SocialButton } from "../../components/SocialButton"
+import { translate } from "../../i18n"
 
 export type Variants = "workshop" | "talk"
 
@@ -78,15 +79,18 @@ const SCREEN_WIDTH = Dimensions.get("screen").width
 const talkDetailsProps = (schedule: ScheduledEvent): TalkDetailsProps => {
   const talk = schedule.talk
 
+  const stringOrPlaceholder = (str?: string) =>
+    str && str.length > 1 ? str : translate("talkDetailsScreen.comingSoon")
+
   return {
     title: talk?.name,
     subtitle: formatDate(schedule["day-time"], "MMMM dd, h:mm aaa"),
     imageUrl: talk?.["speaker-s"][0]?.["speaker-photo"].url,
     fullName: talk?.["speaker-s"][0]?.name,
     company: talk?.["speaker-s"][0]?.company,
-    description: talk?.description,
+    description: stringOrPlaceholder(talk?.description),
     firstName: talk?.["speaker-s"][0]["speaker-first-name"],
-    bio: talk?.["speaker-s"][0]["speaker-bio"],
+    bio: stringOrPlaceholder(talk?.["speaker-s"][0]["speaker-bio"]),
     talkUrl: talk?.["talk-url"],
     eventTime: schedule["day-time"],
     socialButtons: [

--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -20,7 +20,7 @@ import { isFuture, parseISO } from "date-fns"
 import { ScheduledEvent } from "../../services/api/webflow-api.types"
 import { useFloatingActionEvents, useScrollY } from "../../hooks"
 import { SocialButtons } from "../../components/SocialButton"
-import { translate } from "../../i18n"
+import { stringOrPlaceholder } from "../../utils/stringOrPlaceholder"
 
 export type Variants = "workshop" | "talk"
 
@@ -79,18 +79,15 @@ const SCREEN_WIDTH = Dimensions.get("screen").width
 const talkDetailsProps = (schedule: ScheduledEvent): TalkDetailsProps => {
   const talk = schedule.talk
 
-  const stringOrPlaceholder = (str?: string) =>
-    str && str.length > 1 ? str : translate("talkDetailsScreen.comingSoon")
-
   return {
     title: talk?.name,
     subtitle: `${formatDate(schedule["day-time"], "MMMM dd, h:mmaaa")} PT`,
     imageUrl: talk?.["speaker-s"][0]?.["speaker-photo"].url,
     fullName: talk?.["speaker-s"][0]?.name,
     company: talk?.["speaker-s"][0]?.company,
-    description: stringOrPlaceholder(talk?.description),
+    description: stringOrPlaceholder(talk?.description, "talkDetailsScreen.comingSoon"),
     firstName: talk?.["speaker-s"][0]["speaker-first-name"],
-    bio: stringOrPlaceholder(talk?.["speaker-s"][0]["speaker-bio"]),
+    bio: stringOrPlaceholder(talk?.["speaker-s"][0]["speaker-bio"], "talkDetailsScreen.comingSoon"),
     talkUrl: talk?.["talk-url"],
     eventTime: schedule["day-time"],
     socialButtons: [

--- a/app/utils/stringOrPlaceholder.ts
+++ b/app/utils/stringOrPlaceholder.ts
@@ -1,0 +1,20 @@
+import { translate, TxKeyPath } from "../i18n"
+
+/**
+ * Returns a string if it is not empty, otherwise returns a placeholder
+ *
+ * @param string—string—The string to check
+ * @param placeholder-TxKeyPath-The placeholder to return if the string is empty. Uses our i18n key path format.
+ * @returns string
+ *
+ * @example
+ * stringOrPlaceholder("Hello World") // "Hello World"
+ * stringOrPlaceholder("") // "Coming soon"
+ * stringOrPlaceholder(undefined, "common.ok") // "OK!"
+ * stringOrPlaceholder("Hello World", "common.ok") // "Hello World"
+ * stringOrPlaceholder("", "common.ok") // "OK!"
+ */
+export const stringOrPlaceholder = (
+  string?: string,
+  placeholder: TxKeyPath = "common.comingSoon",
+) => (string && string.length > 1 ? string : translate(placeholder))


### PR DESCRIPTION
# Description

[Trello Card](172-when-data-is-missing-add-coming-soon-dont-leave-empty) — #136 
[Trello Card](171-sneaky-data-issues-missing-social-links) — #137 

- making sure talk screens have a "coming soon" label if empty
- updating how we're displaying socials

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| <img src="https://user-images.githubusercontent.com/9324607/233375751-325c1568-8198-4fab-8ddb-e837ce44605b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/9324607/233375889-984bf263-30e1-467d-8ff3-90c72c43bc0b.png" width="300" /> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
