### PR TITLE
Removing Bios from Trivia Show

### DIFF
--- a/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
+++ b/app/screens/TalkDetailsScreen/TalkDetailsScreen.tsx
@@ -117,7 +117,6 @@ const triviaShowProps = (schedule: ScheduledEvent): TalkDetailsProps => {
       imageStyle: { height: 320 },
       subtitle: speaker?.name,
       label: speaker?.company,
-      body: stringOrPlaceholder(speaker?.["speaker-bio"]),
       socialButtons: [
         { url: speaker?.twitter, icon: "twitter" },
         { url: speaker?.github, icon: "github" },


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

[Trello Card]()

Removing Bios from the Trivia Show Panel carousel.

# Graphics

| Before            | After            |
| -------------- | ------------------ |
| <img width="473" alt="image" src="https://user-images.githubusercontent.com/151139/235946950-afafbd72-6f81-4734-8440-f49841b1f17f.png"> | <img width="478" alt="image" src="https://user-images.githubusercontent.com/151139/235947115-6a08fe7f-d1d2-4756-ad8c-d50298f57404.png"> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
