### PR TITLE
Refactor: Schedule Screen Day Picker Slider

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
+++ b/app/screens/ScheduleScreen/ScheduleDayPicker.tsx
@@ -9,7 +9,6 @@ import Animated, {
 } from "react-native-reanimated"
 import { colors, spacing, typography } from "../../theme"
 import { reportCrash } from "../../utils/crashReporting"
-import { parseDate } from "../../utils/formatDate"
 
 const { width } = Dimensions.get("window")
 

--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -277,7 +277,11 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
           />
         )}
       </View>
-      <ScheduleDayPicker {...{ scrollX, onItemPress, schedules, selectedSchedule }} />
+      <ScheduleDayPicker
+        {...{ scrollX, onItemPress }}
+        scheduleDates={schedules.map((s) => parseDate(s.date))}
+        selectedScheduleDate={parseDate(selectedSchedule.date)}
+      />
       <ScrollToButton navigateToCurrentEvent={navigateToCurrentEvent} {...scrollToButtonProps} />
     </>
   )


### PR DESCRIPTION
# Description

This component was receiving all of the data we had for schedules when it only needed dates. Now if we need to change the structure of `schedules` the amount that this component cares about is surfaced at the component interface. We are now expecting these parameters to be of type `Date`. This sets the expectation for the caller.

# Graphics

_There were no graphical changes._

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
