### PR TITLE
(fix) Open Links

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -54,6 +54,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         action: "VIEW",
         data: { scheme: "geo" },
       },
+      {
+        action: "SEND",
+        data: { scheme: "mailto" },
+      },
     ],
   },
   ios: {

--- a/app/utils/openLinkInBrowser.ts
+++ b/app/utils/openLinkInBrowser.ts
@@ -1,11 +1,47 @@
 import { Linking } from "react-native"
 
 /**
+ * Helper to get the social username from a given URL. Mainly Twitter and GitHub.
+ *
+ * @param url The URL to extract the username from.
+ * @returns The username: string
+ *
+ * @example
+ * ```tsx
+ * getSocialUsername("https://twitter.com/mazenchami") // mazenchami
+ * ```
+ */
+const getSocialUsername = (url: string) => {
+  const n = url.lastIndexOf("/")
+  return url.substring(n + 1)
+}
+
+/**
+ * Helper to clean a given URL to be used to open the app as a fallback if the app is installed (Android bug).
+ *
+ * @param url The URL to clean.
+ * @returns The cleaned URL: string
+ *
+ * @example
+ * ```tsx
+ * cleanUrl("https://twitter.com/mazenchami") // twitter://user?screen_name=mazenchami
+ * ```
+ */
+const cleanUrl = (url: string) => {
+  if (url.includes("twitter.com")) {
+    return `twitter://user?screen_name=${getSocialUsername(url)}`
+  }
+  if (url.includes("github.com")) {
+    return `github://user/${getSocialUsername(url)}`
+  }
+  return url
+}
+
+/**
  * Helper for opening a give URL in an external browser.
  */
 export function openLinkInBrowser(url: string) {
-  Linking.canOpenURL(url).then((canOpen) => {
-    console.tron.log({ canOpen })
-    if (canOpen) Linking.openURL(url)
-  })
+  Linking.canOpenURL(url).then((canOpen) =>
+    canOpen ? Linking.openURL(url) : Linking.openURL(cleanUrl(url)),
+  )
 }

--- a/app/utils/openLinkInBrowser.ts
+++ b/app/utils/openLinkInBrowser.ts
@@ -31,9 +31,6 @@ const cleanUrl = (url: string) => {
   if (url.includes("twitter.com")) {
     return `twitter://user?screen_name=${getSocialUsername(url)}`
   }
-  if (url.includes("github.com")) {
-    return `github://user/${getSocialUsername(url)}`
-  }
   return url
 }
 


### PR DESCRIPTION
# Description

#207 
#208 

When an Android device has the app installed (Twitter), we have to explicitly deep link to it or it won't work. Also added a `mailto` intent to help with getting our email client working also

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ios_screenshot | android_screenshot |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
