### PR TITLE
(fix) Android Header Layout Jump

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -5,13 +5,15 @@ import {
   TouchableOpacity,
   TouchableOpacityProps,
   View,
+  ViewProps,
   ViewStyle,
 } from "react-native"
-import { Edge, SafeAreaView, SafeAreaViewProps } from "react-native-safe-area-context"
+import { Edge } from "react-native-safe-area-context"
 import { colors, spacing } from "../theme"
 import { Text, TextProps } from "./Text"
 import { Icon, IconTypes } from "./Icon"
 import { isRTL, translate } from "../i18n"
+import SafeAreaViewFixed from "./SafeAreaViewFixed"
 
 export const MIN_HEADER_HEIGHT = 56
 
@@ -118,9 +120,9 @@ export interface HeaderProps {
    */
   safeAreaEdges?: Edge[]
   /**
-   * Pass any additional props directly to the SafeAreaView component.
+   * Pass any additional props directly to the Header View component.
    */
-  SafeAreaViewProps?: SafeAreaViewProps
+  HeaderViewProps?: ViewProps
 }
 
 interface HeaderActionProps {
@@ -158,7 +160,7 @@ export function Header(props: HeaderProps) {
     rightTx,
     rightTxOptions,
     safeAreaEdges = ["top"],
-    SafeAreaViewProps,
+    HeaderViewProps,
     title,
     titleMode = "center",
     titleTx,
@@ -167,15 +169,13 @@ export function Header(props: HeaderProps) {
     containerStyle: $containerStyleOverride,
   } = props
 
-  const Wrapper = safeAreaEdges?.length ? SafeAreaView : View
-
   const titleContent = titleTx ? translate(titleTx, titleTxOptions) : title
 
   return (
-    <Wrapper
+    <SafeAreaViewFixed
       edges={safeAreaEdges}
-      {...SafeAreaViewProps}
-      style={[$safeArea, SafeAreaViewProps?.style, { backgroundColor }]}
+      {...HeaderViewProps}
+      style={[$safeArea, HeaderViewProps?.style, { backgroundColor }]}
     >
       <View style={[$container, $containerStyleOverride]}>
         <HeaderAction
@@ -213,7 +213,7 @@ export function Header(props: HeaderProps) {
           ActionComponent={RightActionComponent}
         />
       </View>
-    </Wrapper>
+    </SafeAreaViewFixed>
   )
 }
 

--- a/app/components/SafeAreaViewFixed.tsx
+++ b/app/components/SafeAreaViewFixed.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode } from "react"
+import { StyleProp, View, ViewProps, ViewStyle } from "react-native"
+import { Edge, useSafeAreaInsets } from "react-native-safe-area-context"
+
+interface Props extends ViewProps {
+  children: ReactNode
+  style?: StyleProp<ViewStyle>
+  edges?: Edge[]
+}
+
+/**
+ * USE THIS - Alternative to the default [SafeAreaView](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview)
+ * from react-native-safe-area-context which currently has an issue that will cause a flicker / jump on first render on iOS / Android.
+ *
+ * [SafeAreaProvider](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) should still be higher in the tree.
+ *
+ * GitHub issues:
+ * [219](https://github.com/th3rdwave/react-native-safe-area-context/issues/219),
+ * [226](https://github.com/th3rdwave/react-native-safe-area-context/issues/226)
+ */
+export default function SafeAreaViewFixed({ children, style, edges, ...rest }: Props) {
+  const insets = useSafeAreaInsets()
+  const defaultEdges = edges === undefined
+  return (
+    <View
+      style={[
+        {
+          paddingTop: defaultEdges || edges?.includes("top") ? insets.top : undefined,
+          paddingBottom: defaultEdges || edges?.includes("bottom") ? insets.bottom : undefined,
+          paddingLeft: defaultEdges || edges?.includes("left") ? insets.left : undefined,
+          paddingRight: defaultEdges || edges?.includes("right") ? insets.right : undefined,
+        },
+        style,
+      ]}
+      {...rest}
+    >
+      {children}
+    </View>
+  )
+}


### PR DESCRIPTION
# Description

#210 

Found [this](https://github.com/th3rdwave/react-native-safe-area-context/issues/219#issuecomment-1169245221) solution where the `SafeAreaView` had the issue (NOTE: Jamon mentioning this is the fix in the comment right below).

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ios_screenshot | android_screenshot |

# Checklist:

- [ ] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [ ] I have run tests and linter
