### PR TITLE
Adding button text to i18n for scroll to button

### DIFF
--- a/app/components/ScrollToButton.tsx
+++ b/app/components/ScrollToButton.tsx
@@ -108,7 +108,7 @@ export function ScrollToButton(props: ScrollToButtonProps) {
         )}
         preset="reversed"
         style={$scrollButton}
-        text="scroll to current"
+        tx="scheduleScreen.scrollToButton"
         textStyle={$scrollButtonText}
         onPress={navigateToCurrentEvent}
         {...rest}

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -97,6 +97,7 @@ const en = {
     talkRecordingPosted: "Talk recording posted",
     videoComingSoon: "Video coming soon",
     workshopBanner: "Events for workshop ticket-holders",
+    scrollToButton: "scroll to current"
   },
   breakDetailsScreen: {
     description:


### PR DESCRIPTION
# Description

We missed some text in the app to add to our translations file. You can see this button by going through the following steps:

Change line 94 of ScheduleScreen.tsx from:
```typescript
  const date = useCurrentDate()
```
to:
```typescript
  const date = new Date("2023-05-18T21:00:00.000Z") // useCurrentDate()
```

This will manually move you into the middle of the second day. If you scroll up to previous events, you'll see this button appear.

# Graphics

<img width="472" alt="image" src="https://github.com/infinitered/ChainReactApp2023/assets/151139/6358ca00-49a6-46fd-8fe6-b133e138fd0e">

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
