### PR TITLE
:bug: Adding navigation bar color for android

### DIFF
--- a/app/navigators/AppNavigator.tsx
+++ b/app/navigators/AppNavigator.tsx
@@ -60,7 +60,10 @@ const Stack = createNativeStackNavigator<AppStackParamList>()
 
 const AppStack = () => {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName={"Welcome"}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false, navigationBarColor: colors.background }}
+      initialRouteName={"Welcome"}
+    >
       <Stack.Screen name="Debug" component={DebugScreen} />
       <Stack.Screen name="Tabs" component={TabNavigator} />
       <Stack.Screen


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

[Trello Card](190-android-safe-area-loses-background-color)
Fixes #217 

The navigationBar color was not set. It is now the beautiful color of `colors.background`.

# Graphics

| Before            | After             |
| -------------- | ------------------ |
| ![Screenshot_20230510_145845_Chain React App 2023](https://github.com/infinitered/ChainReactApp2023/assets/151139/6c4640d8-b63d-4fa3-a15f-8ec2d74f5d41) | ![Screenshot_20230510_145356_Chain React App 2023](https://github.com/infinitered/ChainReactApp2023/assets/151139/579c63be-9d9b-4f72-8f88-31f9bb421c06) |
| <img width="466" alt="image" src="https://github.com/infinitered/ChainReactApp2023/assets/151139/5c6ec2b9-d705-486f-9668-e3474f5e9d40"> | <img width="469" alt="image" src="https://github.com/infinitered/ChainReactApp2023/assets/151139/4918d301-75e1-477a-b2d4-a6c113c7be83"> |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
