### PR TITLE
Setting width on text container view for wrapping

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -24,7 +24,7 @@ import ScheduleCard, { ScheduleCardProps } from "./ScheduleCard"
 import { parseDate } from "../../utils/formatDate"
 import { format, isAfter } from "date-fns"
 import { useScheduleScreenData } from "../../services/api/webflow-api"
-import { ScrollToButton, Text, useScrollToEvent } from "../../components"
+import { SCREEN_WIDTH, ScrollToButton, Text, useScrollToEvent } from "../../components"
 import { isConferencePassed } from "../../utils/isConferencePassed"
 import * as Device from "expo-device"
 import messaging from "@react-native-firebase/messaging"
@@ -321,6 +321,7 @@ const $workshopBanner: ViewStyle = {
   backgroundColor: colors.palette.primary400,
   paddingHorizontal: spacing.large,
   paddingVertical: spacing.extraSmall,
+  width: SCREEN_WIDTH,
 }
 
 const $workshopBannerText: TextStyle = {


### PR DESCRIPTION
# Description

<!--# NOTE: Please remove our Trello "ID" from the link. i.e. the "link" would look something like `123-feature-ticket`-->

[Trello Card]()

Setting the text container width so that the text will wrap properly. I'm not exactly sure as to why it isn't pulling the width from the container, but I have a feeling this will be more obvious when I refactor this into a `ScreenTab` component.

Note: Volume indicator is not relevant to the after screenshot. It's just there to show that I failed to take the screenshot the first time with one hand. I'm getting better at it, but more practice is evidently required. 😜 

# Graphics

| Before            | After            |
| -------------- | ------------------ |
| ![Screenshot_20230510_154247_Chain React App 2023](https://github.com/infinitered/ChainReactApp2023/assets/151139/4d796ba1-7e2d-4655-80d2-f3314db27d73) | ![Screenshot_20230510_153508_Chain React App 2023](https://github.com/infinitered/ChainReactApp2023/assets/151139/f74e8679-3e29-4d28-bf50-4f08dd611add)|

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
