### PR TITLE
README update on moving to your own Expo account

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ This is for distributing the app to internal testers to run on their devices. Th
 5. Install via QR Code (make sure you don't have any development builds already installed)
 6. You're good to go!
 
+## Moving to your own Expo account
+
+If you'd like to fork this repo and use it on your own Expo account to be able to leverage builds on your own devices, you'll need to do the following:
+
+1. [Fork this repo](https://github.com/infinitered/ChainReactApp2023/fork)
+2. `yarn install`
+3. Head to the `expo.dev` projects dashboard: https://expo.dev/accounts/{username}/projects (Be sure to update `{username}` with your Expo username)
+4. Click on `Create a Project`
+5. In `/app.config.ts` update the following values from your newly generated project found at https://expo.dev/accounts/{username}/projects/{slug}:
+   1. `owner`
+   2. `plugins.expo-updates.username`,
+   3. `slug`
+   4. `extra.eas.projectId`
+6. Follow above steps for building app on either simulator/emulator or device on your platform of choice
+7. Happy Coding!
+
 # E2E Tests
 
 ## Maestro Installation

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -97,7 +97,7 @@ const en = {
     talkRecordingPosted: "Talk recording posted",
     videoComingSoon: "Video coming soon",
     workshopBanner: "Events for workshop ticket-holders",
-    scrollToButton: "scroll to current"
+    scrollToButton: "scroll to current",
   },
   breakDetailsScreen: {
     description:


### PR DESCRIPTION
# Description

Adding documentation to the README file on moving to your own Expo account. We've had this topic come up for users looking to build on their own iOS accounts.

NOTE: running `yarn lint` made a fix to the `en.ts` file thats all fixed here

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
