### PR TITLE
:recycle: Pushing banners down to the data layer

### DIFF
--- a/app/screens/ScheduleScreen/ScheduleScreen.tsx
+++ b/app/screens/ScheduleScreen/ScheduleScreen.tsx
@@ -28,9 +28,10 @@ import { SCREEN_WIDTH, ScrollToButton, Text, useScrollToEvent } from "../../comp
 import { isConferencePassed } from "../../utils/isConferencePassed"
 import * as Device from "expo-device"
 import messaging from "@react-native-firebase/messaging"
-import { translate } from "../../i18n"
+import { TxKeyPath } from "../../i18n"
 
 export interface Schedule {
+  bannerTx?: TxKeyPath
   date: string
   title: string
   events: ScheduleCardProps[]
@@ -207,9 +208,9 @@ export const ScheduleScreen: React.FC<TabScreenProps<"Schedule">> = () => {
   const renderSchedule = React.useCallback(
     ({ index, item: schedule }: { index: number; item: Schedule }) => (
       <>
-        {index === 0 && (
+        {schedule.bannerTx && (
           <View style={$workshopBanner}>
-            <Text style={$workshopBannerText}>{translate("scheduleScreen.workshopBanner")}</Text>
+            <Text style={$workshopBannerText} tx={schedule.bannerTx} />
           </View>
         )}
         <View style={[$container, { width }]}>

--- a/app/services/api/webflow-api.ts
+++ b/app/services/api/webflow-api.ts
@@ -122,6 +122,7 @@ export const useScheduleScreenData = () => {
     isRefetching,
     schedules: [
       {
+        bannerTx: "scheduleScreen.workshopBanner",
         date: "2023-05-17",
         title: "React Native Workshops",
         events: convertScheduleToScheduleCard(events, "Wednesday"),


### PR DESCRIPTION
# Description

This is just a quick refactor so we aren't depending on _magic_ indexes for whether we show a banner on a particular schedule day.

# Graphics

No visual changes.

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
