### PR TITLE
(fix) Adding Accessibility Props to `SocialButton`

### DIFF
--- a/app/components/SocialButton.tsx
+++ b/app/components/SocialButton.tsx
@@ -34,6 +34,9 @@ export function SocialButton(props: SocialButtonProps) {
         openLinkInBrowser(url)
       }}
       style={[$socialButton, $styleOverride]}
+      accessibilityRole="button"
+      accessibilityLabel={icon}
+      accessibilityHint={`Navigates to ${icon}`}
       {...rest}
     >
       <Icon icon={icon} size={size} />


### PR DESCRIPTION
# Description

#227 

Adding some Accessibility Props to make sure our screen reader reads out the `SocialButtons` as expected

# Graphics

| iOS            | Android            |
| -------------- | ------------------ |
| ios_screenshot | android_screenshot |

# Checklist:

- [x] I have done a thorough self-review of my code
- [ ] I have tested with a screen reader and font-scaling turned on and added necessary accessibility features
- [x] I have run tests and linter
